### PR TITLE
Print board module

### DIFF
--- a/controlador_impressao.vhd
+++ b/controlador_impressao.vhd
@@ -1,0 +1,54 @@
+-- VHDL do controlador de impressao do tabuleiro
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity controlador_impressao is
+  port(
+    clock                   : in std_logic;
+    reset                   : in std_logic;
+    comeca_impressao        : in std_logic;
+    uart_livre              : in std_logic;
+    posicao_leitura         : out std_logic_vector(5 downto 0);
+    leitura_memoria         : out std_logic;
+    transmite_dado          : out std_logic;
+    pronto                  : out std_logic
+  );
+end controlador_impressao;
+
+architecture exemplo of controlador_impressao is
+
+  component unidade_controle_tabuleiro is
+    port(
+      clock               : in std_logic;
+      reset               : in std_logic;
+      start               : in std_logic;
+      fim_contagem        : in std_logic;
+      uart_livre          : in std_logic;
+      transmite_dado      : out std_logic;
+      atualiza_caractere  : out std_logic;
+      pronto              : out std_logic
+    );
+  end component;
+
+  component contador_tabuleiro is
+    port(
+      clock     : in  std_logic;
+      zera      : in  std_logic;
+      conta     : in  std_logic;
+      contagem  : out std_logic_vector(5 downto 0);
+      fim       : out std_logic
+    );
+  end component;
+
+  signal sinal_pronto, sinal_atualiza_caractere, sinal_fim_contagem: std_logic;
+
+begin
+
+  unidade_controle: unidade_controle_tabuleiro port map (clock, reset, comeca_impressao, sinal_fim_contagem, uart_livre, transmite_dado, sinal_atualiza_caractere, sinal_pronto);
+  fluxo_dados: contador_tabuleiro port map (clock, sinal_pronto, sinal_atualiza_caractere, posicao_leitura, sinal_fim_contagem);
+
+  pronto <= sinal_pronto;
+  leitura_memoria <= sinal_atualiza_caractere;
+
+end exemplo;

--- a/fluxo_dados_interface_jogo.vhd
+++ b/fluxo_dados_interface_jogo.vhd
@@ -5,38 +5,32 @@ use ieee.std_logic_1164.all;
 
 entity fluxo_dados_interface_jogo is
   port(
-    clock                   : in  std_logic;
-    reset                   : in  std_logic;
-    limpa                   : in  std_logic;
-    conta                   : in  std_logic;
-    leitura                 : in  std_logic;
-    escrita                 : in  std_logic;
-    recebe_dado             : in  std_logic;
-    transmite_dado          : in  std_logic;
-    entrada_serial          : in  std_logic;
-    verificar_fim           : in  std_logic;
-    limpa_valida_jogada     : in  std_logic;
-    saida_serial            : out std_logic;
-    fim_tabuleiro           : out std_logic;
-    fim_recepcao            : out std_logic;
-    uart_livre              : out std_logic;
-    fim_validacao_tabuleiro : out std_logic;
-    fim_jogo                : out std_logic;
-    jogada_ok               : out std_logic;
-    dep_endereco_leitura    : out std_logic_vector(5 downto 0);
-    dep_endereco_escrita    : out std_logic_vector(5 downto 0)
+    clock             : in  std_logic;
+    reset             : in  std_logic;
+    escreve_memoria   : in  std_logic;    -- habilita a escrita na memoria
+    recebe_dado       : in  std_logic;    -- habilita a recepção de dados na uart
+    imprime_tabuleiro : in  std_logic;    -- habilita o circuito de controle de impressao
+    entrada_serial    : in  std_logic;    -- entrada de dados do terminal para a uart
+    saida_serial      : out std_logic;    -- saida de dados da uart para o terminal
+    fim_impressao     : out std_logic;    -- indica o fim da impressao do tabuleiro no terminal
+    fim_recepcao      : out std_logic;    -- indica o fim da recepção de um caractere do terminal na uart
+    fim_jogo          : out std_logic;    -- indica que o jogo acabou por vitoria ou empate
+    jogada_ok         : out std_logic     -- indica que a jogada realizada é valida
   );
 end fluxo_dados_interface_jogo;
 
 architecture exemplo of fluxo_dados_interface_jogo is
 
-  component contador_tabuleiro is
+  component controlador_impressao is
     port(
-      clock     : in  std_logic;
-      zera      : in  std_logic;
-      conta     : in  std_logic;
-      contagem  : out std_logic_vector(5 downto 0);
-      fim       : out std_logic
+      clock                   : in std_logic;
+      reset                   : in std_logic;
+      comeca_impressao        : in std_logic;
+      uart_livre              : in std_logic;
+      posicao_leitura         : out std_logic_vector(5 downto 0);
+      leitura_memoria         : out std_logic;
+      transmite_dado          : out std_logic;
+      pronto                  : out std_logic
     );
   end component;
 
@@ -79,11 +73,7 @@ architecture exemplo of fluxo_dados_interface_jogo is
       dado_rec              : out std_logic_vector(6 downto 0);
       tem_dado_rec          : out std_logic;
       transm_andamento      : out std_logic;
-      fim_transmissao       : out std_logic;
-      dep_tick_rx           : out std_logic;
-      dep_tick_tx           : out std_logic;
-      dep_estado_recepcao   : out std_logic_vector(5 downto 0);
-      dep_habilita_recepcao : out std_logic
+      fim_transmissao       : out std_logic
     );
   end component;
 
@@ -109,34 +99,31 @@ architecture exemplo of fluxo_dados_interface_jogo is
 
   component verifica_fim is
     port(
-      clock         : in  std_logic;
-      enable        : in  std_logic;
-      jogador_atual : in  std_logic;
-      jogadas       : in  std_logic_vector(8 downto 0);
-      jogador       : in  std_logic_vector(8 downto 0);
-      fim_jogo      : out std_logic;
-      fim_validacao : out std_logic
+      jogador_atual: in std_logic;
+      jogadas_realizadas: in std_logic_vector(8 downto 0);
+      jogador_responsavel: in std_logic_vector(8 downto 0);
+      fim_jogo: out std_logic
     );
   end component;
 
-signal s_limpa: std_logic;
 signal s_endereco_leitura, s_endereco_escrita: std_logic_vector(5 downto 0);
 signal s_entrada_caractere, s_saida_caractere: std_logic_vector(6 downto 0);
 signal s_jogadas, s_jogador: std_logic_vector(8 downto 0);
 signal s_posicao: std_logic_vector(3 downto 0);
 signal s_jogador_atual: std_logic;
+signal s_uart_livre: std_logic;
+signal s_transmite_dado: std_logic;
+signal s_leitura_memoria: std_logic;
 
 begin
-  contador      : contador_tabuleiro port map (clock, s_limpa, conta, s_endereco_leitura, fim_tabuleiro);
-  memoria       : memoria_caractere  port map (clock, reset, leitura, escrita, s_endereco_leitura, s_endereco_escrita, s_saida_caractere, s_jogador_atual);
-  mapeador_char : mapeador_caractere port map (s_entrada_caractere, s_endereco_escrita);
-  uart_1        : uart               port map (clock, reset, entrada_serial, recebe_dado, transmite_dado, s_saida_caractere, saida_serial, s_entrada_caractere, fim_recepcao, open, uart_livre, open, open, open, open);
-  mapeador_jogo : mapeador_jogada    port map (s_entrada_caractere, s_posicao);
-  valida_jog    : valida_jogada      port map (s_entrada_caractere, s_jogadas, jogada_ok);
-  jogadas       : registrador_jogada port map (clock, reset, escrita, s_jogador_atual, s_posicao, s_jogadas, s_jogador);
-  final_jogo    : verifica_fim       port map (clock, verificar_fim, s_jogador_atual, s_jogadas, s_jogador, fim_jogo, fim_validacao_tabuleiro);
 
-  s_limpa <= reset or limpa;
-  dep_endereco_leitura <= s_endereco_leitura;
-  dep_endereco_escrita <= s_endereco_escrita;
+  controle_impressao: controlador_impressao port map (clock, reset, imprime_tabuleiro, s_uart_livre, s_endereco_leitura, s_leitura_memoria, s_transmite_dado, fim_impressao);
+  memoria: memoria_caractere port map (clock, reset, s_leitura_memoria, escreve_memoria, s_endereco_leitura, s_endereco_escrita, s_saida_caractere, s_jogador_atual);
+  mapeador_char: mapeador_caractere port map (s_entrada_caractere, s_endereco_escrita);
+  uart_1: uart port map (clock, reset, entrada_serial, recebe_dado, s_transmite_dado, s_saida_caractere, saida_serial, s_entrada_caractere, fim_recepcao, open, s_uart_livre);
+  mapeador_jogo: mapeador_jogada port map (s_entrada_caractere, s_posicao);
+  jogada_valida: valida_jogada port map (s_entrada_caractere, s_jogadas, jogada_ok);
+  jogadas: registrador_jogada port map (clock, reset, escreve_memoria, s_jogador_atual, s_posicao, s_jogadas, s_jogador);
+  final_jogo: verifica_fim port map (s_jogador_atual, s_jogadas, s_jogador, fim_jogo);
+
 end exemplo;

--- a/jogo_velha.vhd
+++ b/jogo_velha.vhd
@@ -11,70 +11,52 @@ entity jogo_velha is
     start: in std_logic;
     saida_serial: out std_logic;
     fim: out std_logic;
-    dep_estados: out std_logic_vector(2 downto 0);
-    dep_fim_recepcao: out std_logic;
-    dep_fim_impressao: out std_logic
+    dep_estados: out std_logic_vector(2 downto 0)
   );
 end jogo_velha;
 
 architecture estrutural of jogo_velha is
+
   component unidade_controle_interface_jogo is
-     port(
-      clock: in std_logic;
-      reset: in std_logic;
-      start: in std_logic;
-      fim_impressao: in std_logic;
-      fim_recepcao: in std_logic;
-      fim_validacao_tabuleiro: in std_logic;
-      jogada_ok: in std_logic;
-      fim_jogo: in std_logic;
-      uart_livre: in std_logic;
-      imprime_tabuleiro: out std_logic;
-      atualiza_caractere: out std_logic;
-      recebe_dado: out std_logic;
-      limpa_contador: out std_logic;
-      insere_dado: out std_logic;
-      verifica_tabuleiro: out std_logic;
-      jogo_acabado: out std_logic;
-      limpa_valida_jogada: out std_logic;
-      dep_estados: out std_logic_vector(2 downto 0)
+    port(
+      clock               : in std_logic;
+      reset               : in std_logic;
+      start               : in std_logic;
+      fim_impressao       : in std_logic;
+      fim_recepcao        : in std_logic;
+      jogada_ok           : in std_logic;
+      fim_jogo            : in std_logic;
+      imprime_tabuleiro   : out std_logic;
+      recebe_dado         : out std_logic;
+      insere_dado         : out std_logic;
+      jogo_acabado        : out std_logic;
+      dep_estados         : out std_logic_vector(2 downto 0)
     );
   end component;
 
   component fluxo_dados_interface_jogo is
     port(
-      clock                   : in  std_logic;
-      reset                   : in  std_logic;
-      limpa                   : in  std_logic;
-      conta                   : in  std_logic;
-      leitura                 : in  std_logic;
-      escrita                 : in  std_logic;
-      recebe_dado             : in  std_logic;
-      transmite_dado          : in  std_logic;
-      entrada_serial          : in  std_logic;
-      verificar_fim           : in  std_logic;
-      limpa_valida_jogada     : in  std_logic;
-      saida_serial            : out std_logic;
-      fim_tabuleiro           : out std_logic;
-      fim_recepcao            : out std_logic;
-      uart_livre              : out std_logic;
-      fim_validacao_tabuleiro : out std_logic;
-      fim_jogo                : out std_logic;
-      jogada_ok               : out std_logic;
-      dep_endereco_leitura    : out std_logic_vector(5 downto 0);
-      dep_endereco_escrita    : out std_logic_vector(5 downto 0)
+      clock             : in  std_logic;
+      reset             : in  std_logic;
+      escreve_memoria   : in  std_logic;
+      recebe_dado       : in  std_logic;
+      imprime_tabuleiro : in  std_logic;
+      entrada_serial    : in  std_logic;
+      saida_serial      : out std_logic;
+      fim_impressao     : out std_logic;
+      fim_recepcao      : out std_logic;
+      fim_jogo          : out std_logic;
+      jogada_ok         : out std_logic
     );
   end component;
 
-  signal s_fim_impressao, s_uart_livre, s_imprime_tabuleiro, s_atualiza_caractere, s_limpa_contador: std_logic;
-  signal s_fim_recepcao, s_recebe_dado, s_insere_dado, s_jogada_ok, s_verifica_jogada: std_logic;
-  signal s_verifica_tabuleiro, s_fim_validacao_tabuleiro, s_fim_validacao_jogada, s_fim_jogo: std_logic;
-  signal s_limpa_valida_jogada: std_logic;
+  signal s_fim_impressao, s_imprime_tabuleiro: std_logic;         -- relacionados a impressão do tabuleiro
+  signal s_fim_recepcao, s_recebe_dado, s_insere_dado: std_logic; -- relacionados a recepção do dado
+  signal s_fim_jogo, s_jogada_ok: std_logic;                      -- relacionados a validações/verificações
+
 begin
 
-    unidade_controle : unidade_controle_interface_jogo port map (clock, reset, start, s_fim_impressao, s_fim_recepcao, s_fim_validacao_tabuleiro, s_jogada_ok, s_fim_jogo, s_uart_livre, s_imprime_tabuleiro, s_atualiza_caractere, s_recebe_dado, s_limpa_contador, s_insere_dado, s_verifica_tabuleiro, fim, s_limpa_valida_jogada, dep_estados);
-    fluxo_dados: fluxo_dados_interface_jogo port map(clock, reset, s_limpa_contador, s_atualiza_caractere, s_atualiza_caractere, s_insere_dado, s_recebe_dado, s_imprime_tabuleiro, entrada_serial, s_verifica_tabuleiro, s_limpa_valida_jogada, saida_serial, s_fim_impressao, s_fim_recepcao, s_uart_livre, s_fim_validacao_tabuleiro, s_fim_jogo, s_jogada_ok, open, open);
+    unidade_controle : unidade_controle_interface_jogo port map (clock, reset, start, s_fim_impressao, s_fim_recepcao, s_jogada_ok, s_fim_jogo, s_imprime_tabuleiro, s_recebe_dado, s_insere_dado, fim, dep_estados);
+    fluxo_dados: fluxo_dados_interface_jogo port map(clock, reset, s_insere_dado, s_recebe_dado, s_imprime_tabuleiro, entrada_serial, saida_serial, s_fim_impressao, s_fim_recepcao, s_fim_jogo, s_jogada_ok);
 
-    dep_fim_recepcao <= s_fim_recepcao;
-    dep_fim_impressao <= s_fim_impressao;
 end estrutural;

--- a/memoria_caractere.vhd
+++ b/memoria_caractere.vhd
@@ -35,6 +35,7 @@ begin
   process (clock, reset, leitura, escrita)
   begin
     if reset='1' then
+      sinal_jogador <= '0';
       memoria_tabuleiro <= (c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
                             c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
                             c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,

--- a/uart.vhd
+++ b/uart.vhd
@@ -16,11 +16,7 @@ entity uart is
     dado_rec: out std_logic_vector(6 downto 0);
     tem_dado_rec: out std_logic;
     transm_andamento: out std_logic;
-    fim_transmissao: out std_logic;
-    dep_tick_rx: out std_logic;
-    dep_tick_tx: out std_logic;
-    dep_estado_recepcao: out std_logic_vector(5 downto 0);
-    dep_habilita_recepcao: out std_logic
+    fim_transmissao: out std_logic
   );
 end uart;
 
@@ -66,8 +62,8 @@ architecture estrutural of uart is
 
 begin
 
-  transmissao: transmissao_serial port map (clock, reset, transmite_dado, dado_trans, saida, fim_transmissao, transm_andamento, dep_tick_tx);
-  recepcao: recepcao_serial port map(clock, reset, entrada, recebe_dado, sinal_dado_rec, tem_dado_rec, open, dep_tick_rx, dep_estado_recepcao, dep_habilita_recepcao);
+  transmissao: transmissao_serial port map (clock, reset, transmite_dado, dado_trans, saida, fim_transmissao, transm_andamento, open);
+  recepcao: recepcao_serial port map(clock, reset, entrada, recebe_dado, sinal_dado_rec, tem_dado_rec, open, open, open, open);
 
   dado_rec <= sinal_dado_rec(8 downto 2);
   --display_1: hex7seg_en port map(sinal_dado_rec(5), sinal_dado_rec(4), sinal_dado_rec(3), sinal_dado_rec(2), '1', dado_rec(0), dado_rec(1), dado_rec(2), dado_rec(3), dado_rec(4), dado_rec(5), dado_rec(6));

--- a/unidade_controle_tabuleiro.vhd
+++ b/unidade_controle_tabuleiro.vhd
@@ -1,0 +1,72 @@
+-- VHDL da Unidade de Controle do modulo de impressão do tabuleiro
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity unidade_controle_tabuleiro is
+  port(
+    clock: in std_logic;
+    reset: in std_logic;
+    start: in std_logic;
+    fim_contagem: in std_logic;
+    uart_livre: in std_logic;
+    transmite_dado: out std_logic;
+    atualiza_caractere: out std_logic;
+    pronto: out std_logic
+  );
+end unidade_controle_tabuleiro;
+
+architecture comportamental of unidade_controle_tabuleiro is
+type tipo_estado is (inicial, prepara, imprime, final);
+signal estado   : tipo_estado;
+
+begin
+    process (clock, estado, reset)
+    begin
+
+    if reset = '1' then
+      estado <= inicial;
+    elsif (clock'event and clock = '1') then
+      case estado is
+        when inicial =>                -- Aguarda sinal de start
+          if start = '1' then
+            estado <= prepara;
+          else
+            estado <= inicial;
+          end if;
+
+        when prepara =>
+          if fim_contagem = '1' then
+            estado <= final;
+          else
+            estado <= imprime;
+          end if;
+
+        when imprime =>                -- Imprime o tabuleiro no terminal
+          if uart_livre = '1' then
+            estado <= prepara;
+          else
+            estado <= imprime;
+          end if;
+
+        when final =>
+          estado <= inicial;
+
+        when others =>       -- Default
+          estado <= inicial;
+      end case;
+    end if;
+    end process;
+
+    -- logica de saída
+    with estado select
+      transmite_dado <= '1' when imprime,
+                        '0' when others;
+
+    with estado select
+      atualiza_caractere <= '1' when prepara,
+                            '0' when others;
+
+    with estado select
+      pronto <= '1' when final,
+                '0' when others;
+end comportamental;

--- a/verifica_fim.vhd
+++ b/verifica_fim.vhd
@@ -6,48 +6,32 @@ use ieee.std_logic_arith.all;
 
 entity verifica_fim is
     port(
-      clock: in std_logic;
-      enable: in std_logic;
-      jogador_atual: in std_logic;
-      jogadas: in std_logic_vector(8 downto 0);
-      jogador: in std_logic_vector(8 downto 0);
-      fim_jogo: out std_logic;
-      fim_validacao: out std_logic
+      jogador_atual: in std_logic;                          -- jogador atual de acordo com a memoria do tabuleiro
+      jogadas_realizadas: in std_logic_vector(8 downto 0);  -- vetor com as jogadas(1 ocupado, 0 aberto)
+      jogador_responsavel: in std_logic_vector(8 downto 0); -- vetor com o jogador(1 jogador 1, 0 jogador 0)
+      fim_jogo: out std_logic                               -- indica o fim do jogo
     );
 end verifica_fim;
 
 architecture exemplo of verifica_fim is
-signal sinal_fim, sinal_fim_validacao: std_logic;
+signal sinal_fim: std_logic;
 signal sinal_jogadas_jogador: std_logic_vector(8 downto 0);
 begin
-  process (clock, enable, jogador_atual)
+  process (jogador_atual)
   begin
-
-  if clock'event and clock = '1' then
-    if enable = '1' then
-      if jogadas = "111111111" then
-        sinal_fim <= '1';
-      else
-        if jogador_atual='0' then
-          sinal_jogadas_jogador <= jogadas and jogador;
-        else
-          sinal_jogadas_jogador <= jogadas and (not jogador);
-        end if;
-        sinal_fim <= ((sinal_jogadas_jogador(0) and sinal_jogadas_jogador(1) and sinal_jogadas_jogador(2)) or
-                      (sinal_jogadas_jogador(3) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(5)) or
-                      (sinal_jogadas_jogador(6) and sinal_jogadas_jogador(7) and sinal_jogadas_jogador(8)) or
-                      (sinal_jogadas_jogador(0) and sinal_jogadas_jogador(3) and sinal_jogadas_jogador(6)) or
-                      (sinal_jogadas_jogador(1) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(7)) or
-                      (sinal_jogadas_jogador(2) and sinal_jogadas_jogador(5) and sinal_jogadas_jogador(8)) or
-                      (sinal_jogadas_jogador(0) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(8)) or
-                      (sinal_jogadas_jogador(6) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(2)));
-      end if;
-      sinal_fim_validacao <= '1';
+    if jogador_atual='1' then
+      sinal_jogadas_jogador <= jogadas_realizadas and jogador_responsavel;
     else
-      sinal_fim_validacao <= '0';
+      sinal_jogadas_jogador <= jogadas_realizadas and (not jogador_responsavel);
     end if;
-  end if;
-  fim_jogo <= sinal_fim;
-  fim_validacao <= sinal_fim_validacao;
+    sinal_fim <= ((sinal_jogadas_jogador(0) and sinal_jogadas_jogador(1) and sinal_jogadas_jogador(2)) or
+                  (sinal_jogadas_jogador(3) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(5)) or
+                  (sinal_jogadas_jogador(6) and sinal_jogadas_jogador(7) and sinal_jogadas_jogador(8)) or
+                  (sinal_jogadas_jogador(0) and sinal_jogadas_jogador(3) and sinal_jogadas_jogador(6)) or
+                  (sinal_jogadas_jogador(1) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(7)) or
+                  (sinal_jogadas_jogador(2) and sinal_jogadas_jogador(5) and sinal_jogadas_jogador(8)) or
+                  (sinal_jogadas_jogador(0) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(8)) or
+                  (sinal_jogadas_jogador(6) and sinal_jogadas_jogador(4) and sinal_jogadas_jogador(2)));
+    fim_jogo <= sinal_fim;
   end process;
 end exemplo;


### PR DESCRIPTION
## Issue
#10 

## Descrição
Adiciona um módulo para o controle da impressão do tabuleiro

## Objetivo
Modificar o projeto a fim de isolar a logica de controle de impressão em um módulo

## Decisões
*  Refatorei a unidade de controle e o fluxo de dados do jogo, removendo partes desnecessárias
*  Adicionei um módulo(UC + FD) para o controle da impressão de dados
*  Removi um estado da UC do jogo, ficando apenas um estado responsável pela impressão
*  Deixei a verificação do fim de jogo para ser assíncrona, assim como acontece para a jogada
