### PR TITLE
added clear screen and set cursor to 0,0

### DIFF
--- a/contador_tabuleiro.vhd
+++ b/contador_tabuleiro.vhd
@@ -9,13 +9,13 @@ entity contador_tabuleiro is
       clock     : in  std_logic;
       zera      : in  std_logic;
       conta     : in  std_logic;
-      contagem  : out std_logic_vector(6 downto 0);
+      contagem  : out std_logic_vector(5 downto 0);
       fim       : out std_logic
     );
 end contador_tabuleiro;
 
 architecture exemplo of contador_tabuleiro is
-signal IQ: unsigned(6 downto 0);
+signal IQ: unsigned(5 downto 0);
 
 begin
   process (clock, conta, IQ, zera)
@@ -29,7 +29,7 @@ begin
     end if;
   end if;
 
-  if IQ = 70 then
+  if IQ = 64 then
     fim <= '1';
   else
     fim <= '0';

--- a/contador_tabuleiro.vhd
+++ b/contador_tabuleiro.vhd
@@ -9,13 +9,13 @@ entity contador_tabuleiro is
       clock     : in  std_logic;
       zera      : in  std_logic;
       conta     : in  std_logic;
-      contagem  : out std_logic_vector(5 downto 0);
+      contagem  : out std_logic_vector(6 downto 0);
       fim       : out std_logic
     );
 end contador_tabuleiro;
 
 architecture exemplo of contador_tabuleiro is
-signal IQ: unsigned(5 downto 0);
+signal IQ: unsigned(6 downto 0);
 
 begin
   process (clock, conta, IQ, zera)

--- a/contador_tabuleiro.vhd
+++ b/contador_tabuleiro.vhd
@@ -9,13 +9,13 @@ entity contador_tabuleiro is
       clock     : in  std_logic;
       zera      : in  std_logic;
       conta     : in  std_logic;
-      contagem  : out std_logic_vector(5 downto 0);
+      contagem  : out std_logic_vector(6 downto 0);
       fim       : out std_logic
     );
 end contador_tabuleiro;
 
 architecture exemplo of contador_tabuleiro is
-signal IQ: unsigned(5 downto 0);
+signal IQ: unsigned(6 downto 0);
 
 begin
   process (clock, conta, IQ, zera)
@@ -29,7 +29,7 @@ begin
     end if;
   end if;
 
-  if IQ = 60 then
+  if IQ = 76 then
     fim <= '1';
   else
     fim <= '0';

--- a/contador_tabuleiro.vhd
+++ b/contador_tabuleiro.vhd
@@ -29,7 +29,7 @@ begin
     end if;
   end if;
 
-  if IQ = 76 then
+  if IQ = 70 then
     fim <= '1';
   else
     fim <= '0';

--- a/controlador_impressao.vhd
+++ b/controlador_impressao.vhd
@@ -9,7 +9,7 @@ entity controlador_impressao is
     reset                   : in std_logic;
     comeca_impressao        : in std_logic;
     uart_livre              : in std_logic;
-    posicao_leitura         : out std_logic_vector(6 downto 0);
+    posicao_leitura         : out std_logic_vector(5 downto 0);
     leitura_memoria         : out std_logic;
     transmite_dado          : out std_logic;
     pronto                  : out std_logic
@@ -36,7 +36,7 @@ architecture exemplo of controlador_impressao is
       clock     : in  std_logic;
       zera      : in  std_logic;
       conta     : in  std_logic;
-      contagem  : out std_logic_vector(6 downto 0);
+      contagem  : out std_logic_vector(5 downto 0);
       fim       : out std_logic
     );
   end component;

--- a/controlador_impressao.vhd
+++ b/controlador_impressao.vhd
@@ -9,7 +9,7 @@ entity controlador_impressao is
     reset                   : in std_logic;
     comeca_impressao        : in std_logic;
     uart_livre              : in std_logic;
-    posicao_leitura         : out std_logic_vector(5 downto 0);
+    posicao_leitura         : out std_logic_vector(6 downto 0);
     leitura_memoria         : out std_logic;
     transmite_dado          : out std_logic;
     pronto                  : out std_logic
@@ -36,7 +36,7 @@ architecture exemplo of controlador_impressao is
       clock     : in  std_logic;
       zera      : in  std_logic;
       conta     : in  std_logic;
-      contagem  : out std_logic_vector(5 downto 0);
+      contagem  : out std_logic_vector(6 downto 0);
       fim       : out std_logic
     );
   end component;

--- a/fluxo_dados_interface_jogo.vhd
+++ b/fluxo_dados_interface_jogo.vhd
@@ -27,7 +27,7 @@ architecture exemplo of fluxo_dados_interface_jogo is
       reset                   : in std_logic;
       comeca_impressao        : in std_logic;
       uart_livre              : in std_logic;
-      posicao_leitura         : out std_logic_vector(6 downto 0);
+      posicao_leitura         : out std_logic_vector(5 downto 0);
       leitura_memoria         : out std_logic;
       transmite_dado          : out std_logic;
       pronto                  : out std_logic
@@ -40,8 +40,8 @@ architecture exemplo of fluxo_dados_interface_jogo is
       reset             : in  std_logic;
       leitura           : in  std_logic;
       escrita           : in  std_logic;
-      endereco_leitura  : in  std_logic_vector(6 downto 0);
-      endereco_escrita  : in  std_logic_vector(6 downto 0);
+      endereco_leitura  : in  std_logic_vector(5 downto 0);
+      endereco_escrita  : in  std_logic_vector(5 downto 0);
       saida             : out std_logic_vector(6 downto 0);
       jogador           : out std_logic
     );
@@ -50,7 +50,7 @@ architecture exemplo of fluxo_dados_interface_jogo is
   component mapeador_caractere is
     port(
       caractere       : in  std_logic_vector(6 downto 0);
-      posicao_memoria : out std_logic_vector(6 downto 0)
+      posicao_memoria : out std_logic_vector(5 downto 0)
     );
   end component;
 
@@ -106,7 +106,7 @@ architecture exemplo of fluxo_dados_interface_jogo is
     );
   end component;
 
-signal s_endereco_leitura, s_endereco_escrita: std_logic_vector(6 downto 0);
+signal s_endereco_leitura, s_endereco_escrita: std_logic_vector(5 downto 0);
 signal s_entrada_caractere, s_saida_caractere: std_logic_vector(6 downto 0);
 signal s_jogadas, s_jogador: std_logic_vector(8 downto 0);
 signal s_posicao: std_logic_vector(3 downto 0);

--- a/fluxo_dados_interface_jogo.vhd
+++ b/fluxo_dados_interface_jogo.vhd
@@ -27,7 +27,7 @@ architecture exemplo of fluxo_dados_interface_jogo is
       reset                   : in std_logic;
       comeca_impressao        : in std_logic;
       uart_livre              : in std_logic;
-      posicao_leitura         : out std_logic_vector(5 downto 0);
+      posicao_leitura         : out std_logic_vector(6 downto 0);
       leitura_memoria         : out std_logic;
       transmite_dado          : out std_logic;
       pronto                  : out std_logic
@@ -40,8 +40,8 @@ architecture exemplo of fluxo_dados_interface_jogo is
       reset             : in  std_logic;
       leitura           : in  std_logic;
       escrita           : in  std_logic;
-      endereco_leitura  : in  std_logic_vector(5 downto 0);
-      endereco_escrita  : in  std_logic_vector(5 downto 0);
+      endereco_leitura  : in  std_logic_vector(6 downto 0);
+      endereco_escrita  : in  std_logic_vector(6 downto 0);
       saida             : out std_logic_vector(6 downto 0);
       jogador           : out std_logic
     );
@@ -50,7 +50,7 @@ architecture exemplo of fluxo_dados_interface_jogo is
   component mapeador_caractere is
     port(
       caractere       : in  std_logic_vector(6 downto 0);
-      posicao_memoria : out std_logic_vector(5 downto 0)
+      posicao_memoria : out std_logic_vector(6 downto 0)
     );
   end component;
 
@@ -106,7 +106,7 @@ architecture exemplo of fluxo_dados_interface_jogo is
     );
   end component;
 
-signal s_endereco_leitura, s_endereco_escrita: std_logic_vector(5 downto 0);
+signal s_endereco_leitura, s_endereco_escrita: std_logic_vector(6 downto 0);
 signal s_entrada_caractere, s_saida_caractere: std_logic_vector(6 downto 0);
 signal s_jogadas, s_jogador: std_logic_vector(8 downto 0);
 signal s_posicao: std_logic_vector(3 downto 0);

--- a/mapeador_caractere.vhd
+++ b/mapeador_caractere.vhd
@@ -5,7 +5,7 @@ use ieee.std_logic_1164.all;
 entity mapeador_caractere is
   port(
     caractere: in std_logic_vector(6 downto 0);
-    posicao_memoria: out std_logic_vector(5 downto 0)
+    posicao_memoria: out std_logic_vector(6 downto 0)
   );
 end mapeador_caractere;
 
@@ -15,23 +15,23 @@ begin
   begin
     case caractere is
       when "0110111" =>
-        posicao_memoria <= "000001";
+        posicao_memoria <= "0010010";
       when "0111000" =>
-        posicao_memoria <= "000101";
+        posicao_memoria <= "0010110";
       when "0111001" =>
-        posicao_memoria <= "001001";
+        posicao_memoria <= "0011010";
       when "0110100" =>
-        posicao_memoria <= "011001";
+        posicao_memoria <= "0101010";
       when "0110101" =>
-        posicao_memoria <= "011101";
+        posicao_memoria <= "0101110";
       when "0110110" =>
-        posicao_memoria <= "100001";
+        posicao_memoria <= "0110010";
       when "0110001" =>
-        posicao_memoria <= "110001";
+        posicao_memoria <= "0110001";
       when "0110010" =>
-        posicao_memoria <= "110101";
+        posicao_memoria <= "1000010";
       when "0110011" =>
-        posicao_memoria <= "111001";
+        posicao_memoria <= "1001010";
       when others =>
         null;
     end case;

--- a/mapeador_caractere.vhd
+++ b/mapeador_caractere.vhd
@@ -5,7 +5,7 @@ use ieee.std_logic_1164.all;
 entity mapeador_caractere is
   port(
     caractere: in std_logic_vector(6 downto 0);
-    posicao_memoria: out std_logic_vector(6 downto 0)
+    posicao_memoria: out std_logic_vector(5 downto 0)
   );
 end mapeador_caractere;
 
@@ -15,23 +15,23 @@ begin
   begin
     case caractere is
       when "0110111" =>
-        posicao_memoria <= "0001011";
+        posicao_memoria <= "000101";
       when "0111000" =>
-        posicao_memoria <= "0001111";
+        posicao_memoria <= "001001";
       when "0111001" =>
-        posicao_memoria <= "0010011";
+        posicao_memoria <= "001101";
       when "0110100" =>
-        posicao_memoria <= "0100011";
+        posicao_memoria <= "011101";
       when "0110101" =>
-        posicao_memoria <= "0100111";
+        posicao_memoria <= "100001";
       when "0110110" =>
-        posicao_memoria <= "0101011";
+        posicao_memoria <= "100101";
       when "0110001" =>
-        posicao_memoria <= "0111011";
+        posicao_memoria <= "110101";
       when "0110010" =>
-        posicao_memoria <= "0111111";
+        posicao_memoria <= "111001";
       when "0110011" =>
-        posicao_memoria <= "1000011";
+        posicao_memoria <= "111101";
       when others =>
         null;
     end case;

--- a/mapeador_caractere.vhd
+++ b/mapeador_caractere.vhd
@@ -5,7 +5,7 @@ use ieee.std_logic_1164.all;
 entity mapeador_caractere is
   port(
     caractere: in std_logic_vector(6 downto 0);
-    posicao_memoria: out std_logic_vector(5 downto 0)
+    posicao_memoria: out std_logic_vector(6 downto 0)
   );
 end mapeador_caractere;
 
@@ -15,23 +15,23 @@ begin
   begin
     case caractere is
       when "0110111" =>
-        posicao_memoria <= "000101";
+        posicao_memoria <= "0000101";
       when "0111000" =>
-        posicao_memoria <= "001001";
+        posicao_memoria <= "0001001";
       when "0111001" =>
-        posicao_memoria <= "001101";
+        posicao_memoria <= "0001101";
       when "0110100" =>
-        posicao_memoria <= "011101";
+        posicao_memoria <= "0011101";
       when "0110101" =>
-        posicao_memoria <= "100001";
+        posicao_memoria <= "0100001";
       when "0110110" =>
-        posicao_memoria <= "100101";
+        posicao_memoria <= "0100101";
       when "0110001" =>
-        posicao_memoria <= "110101";
+        posicao_memoria <= "0110101";
       when "0110010" =>
-        posicao_memoria <= "111001";
+        posicao_memoria <= "0111001";
       when "0110011" =>
-        posicao_memoria <= "111101";
+        posicao_memoria <= "0111101";
       when others =>
         null;
     end case;

--- a/mapeador_caractere.vhd
+++ b/mapeador_caractere.vhd
@@ -15,23 +15,23 @@ begin
   begin
     case caractere is
       when "0110111" =>
-        posicao_memoria <= "0010010";
+        posicao_memoria <= "0001011";
       when "0111000" =>
-        posicao_memoria <= "0010110";
+        posicao_memoria <= "0001111";
       when "0111001" =>
-        posicao_memoria <= "0011010";
+        posicao_memoria <= "0010011";
       when "0110100" =>
-        posicao_memoria <= "0101010";
+        posicao_memoria <= "0100011";
       when "0110101" =>
-        posicao_memoria <= "0101110";
+        posicao_memoria <= "0100111";
       when "0110110" =>
-        posicao_memoria <= "0110010";
+        posicao_memoria <= "0101011";
       when "0110001" =>
-        posicao_memoria <= "0110001";
+        posicao_memoria <= "0111011";
       when "0110010" =>
-        posicao_memoria <= "1000010";
+        posicao_memoria <= "0111111";
       when "0110011" =>
-        posicao_memoria <= "1001010";
+        posicao_memoria <= "1000011";
       when others =>
         null;
     end case;

--- a/memoria_caractere.vhd
+++ b/memoria_caractere.vhd
@@ -9,8 +9,8 @@ entity memoria_caractere is
       reset: in std_logic;
       leitura: in std_logic;
       escrita: in std_logic;
-      endereco_leitura: in std_logic_vector(5 downto 0);
-      endereco_escrita: in std_logic_vector(5 downto 0);
+      endereco_leitura: in std_logic_vector(6 downto 0);
+      endereco_escrita: in std_logic_vector(6 downto 0);
       saida: out std_logic_vector(6 downto 0);
       jogador: out std_logic
     );

--- a/memoria_caractere.vhd
+++ b/memoria_caractere.vhd
@@ -18,7 +18,7 @@ end memoria_caractere;
 
 architecture estrutural of memoria_caractere is
   signal sinal_jogador: std_logic := '0';
-  type memoria is array (0 to 75) of std_logic_vector(6 downto 0);
+  type memoria is array (0 to 69) of std_logic_vector(6 downto 0);
   constant c_enter: std_logic_vector(6 downto 0) := "0001101";
   constant c_espaco: std_logic_vector(6 downto 0) := "0100000";
   constant c_hifen: std_logic_vector(6 downto 0) := "0101101";
@@ -26,16 +26,15 @@ architecture estrutural of memoria_caractere is
   constant c_pipe: std_logic_vector(6 downto 0) := "1111100";
   constant c_x: std_logic_vector(6 downto 0) := "1011000";
   constant c_o: std_logic_vector(6 downto 0) := "1001111";
-  constant c_contrabarra: std_logic_vector(6 downto 0) := "1011100";
+  constant c_esc: std_logic_vector(6 downto 0) := "0011011";
   constant c_zero: std_logic_vector(6 downto 0) := "0110000";
-  constant c_tres: std_logic_vector(6 downto 0) := "0110000";
   constant c_dois: std_logic_vector(6 downto 0) := "0110010";
   constant c_abrechaves: std_logic_vector(6 downto 0) := "1011011";
   constant c_pontovirgula: std_logic_vector(6 downto 0) := "0111011";
   constant c_J: std_logic_vector(6 downto 0) := "1001010";
   constant c_H: std_logic_vector(6 downto 0) := "1001000";
-  signal memoria_tabuleiro: memoria := (c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_dois, c_J,
-                                        c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
+  signal memoria_tabuleiro: memoria := (c_esc, c_abrechaves, c_dois, c_J,
+                                        c_esc, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
                                         c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
                                         c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
                                         c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
@@ -46,13 +45,13 @@ begin
   begin
     if reset='1' then
       sinal_jogador <= '0';
-      memoria_tabuleiro <= (c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_dois, c_J,
-                            c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
-                            c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
-                            c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
-                            c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
-                            c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
-                            c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter);
+      memoria_tabuleiro <= (c_esc, c_abrechaves, c_dois, c_J,
+        									  c_esc, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
+        									  c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
+        									  c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
+        									  c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
+        									  c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
+        									  c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter);
     elsif clock'event and clock='1' then
       if leitura='1' then
         saida <= memoria_tabuleiro(to_integer(unsigned(endereco_leitura)));

--- a/memoria_caractere.vhd
+++ b/memoria_caractere.vhd
@@ -9,8 +9,8 @@ entity memoria_caractere is
       reset: in std_logic;
       leitura: in std_logic;
       escrita: in std_logic;
-      endereco_leitura: in std_logic_vector(6 downto 0);
-      endereco_escrita: in std_logic_vector(6 downto 0);
+      endereco_leitura: in std_logic_vector(5 downto 0);
+      endereco_escrita: in std_logic_vector(5 downto 0);
       saida: out std_logic_vector(6 downto 0);
       jogador: out std_logic
     );
@@ -18,7 +18,7 @@ end memoria_caractere;
 
 architecture estrutural of memoria_caractere is
   signal sinal_jogador: std_logic := '0';
-  type memoria is array (0 to 69) of std_logic_vector(6 downto 0);
+  type memoria is array (0 to 63) of std_logic_vector(6 downto 0);
   constant c_enter: std_logic_vector(6 downto 0) := "0001101";
   constant c_espaco: std_logic_vector(6 downto 0) := "0100000";
   constant c_hifen: std_logic_vector(6 downto 0) := "0101101";
@@ -27,14 +27,10 @@ architecture estrutural of memoria_caractere is
   constant c_x: std_logic_vector(6 downto 0) := "1011000";
   constant c_o: std_logic_vector(6 downto 0) := "1001111";
   constant c_esc: std_logic_vector(6 downto 0) := "0011011";
-  constant c_zero: std_logic_vector(6 downto 0) := "0110000";
   constant c_dois: std_logic_vector(6 downto 0) := "0110010";
   constant c_abrechaves: std_logic_vector(6 downto 0) := "1011011";
-  constant c_pontovirgula: std_logic_vector(6 downto 0) := "0111011";
   constant c_J: std_logic_vector(6 downto 0) := "1001010";
-  constant c_H: std_logic_vector(6 downto 0) := "1001000";
   signal memoria_tabuleiro: memoria := (c_esc, c_abrechaves, c_dois, c_J,
-                                        c_esc, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
                                         c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
                                         c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
                                         c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
@@ -46,7 +42,6 @@ begin
     if reset='1' then
       sinal_jogador <= '0';
       memoria_tabuleiro <= (c_esc, c_abrechaves, c_dois, c_J,
-        									  c_esc, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
         									  c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
         									  c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
         									  c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,

--- a/memoria_caractere.vhd
+++ b/memoria_caractere.vhd
@@ -9,8 +9,8 @@ entity memoria_caractere is
       reset: in std_logic;
       leitura: in std_logic;
       escrita: in std_logic;
-      endereco_leitura: in std_logic_vector(5 downto 0);
-      endereco_escrita: in std_logic_vector(5 downto 0);
+      endereco_leitura: in std_logic_vector(6 downto 0);
+      endereco_escrita: in std_logic_vector(6 downto 0);
       saida: out std_logic_vector(6 downto 0);
       jogador: out std_logic
     );
@@ -18,7 +18,7 @@ end memoria_caractere;
 
 architecture estrutural of memoria_caractere is
   signal sinal_jogador: std_logic := '0';
-  type memoria is array (0 to 59) of std_logic_vector(6 downto 0);
+  type memoria is array (0 to 75) of std_logic_vector(6 downto 0);
   constant c_enter: std_logic_vector(6 downto 0) := "0001101";
   constant c_espaco: std_logic_vector(6 downto 0) := "0100000";
   constant c_hifen: std_logic_vector(6 downto 0) := "0101101";
@@ -26,7 +26,17 @@ architecture estrutural of memoria_caractere is
   constant c_pipe: std_logic_vector(6 downto 0) := "1111100";
   constant c_x: std_logic_vector(6 downto 0) := "1011000";
   constant c_o: std_logic_vector(6 downto 0) := "1001111";
-  signal memoria_tabuleiro: memoria := (c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
+  constant c_contrabarra: std_logic_vector(6 downto 0) := "1011100";
+  constant c_zero: std_logic_vector(6 downto 0) := "0110000";
+  constant c_tres: std_logic_vector(6 downto 0) := "0110000";
+  constant c_dois: std_logic_vector(6 downto 0) := "0110010";
+  constant c_abrechaves: std_logic_vector(6 downto 0) := "1011011";
+  constant c_pontovirgula: std_logic_vector(6 downto 0) := "0111011";
+  constant c_J: std_logic_vector(6 downto 0) := "1001010";
+  constant c_H: std_logic_vector(6 downto 0) := "1001000";
+  signal memoria_tabuleiro: memoria := (c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_dois, c_J,
+                                        c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
+                                        c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
                                         c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
                                         c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
                                         c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
@@ -36,7 +46,9 @@ begin
   begin
     if reset='1' then
       sinal_jogador <= '0';
-      memoria_tabuleiro <= (c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
+      memoria_tabuleiro <= (c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_dois, c_J,
+                            c_contrabarra, c_zero, c_tres, c_tres, c_abrechaves, c_zero, c_pontovirgula, c_zero, c_H,
+                            c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
                             c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,
                             c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_pipe, c_espaco, c_espaco, c_espaco, c_enter,
                             c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_mais, c_hifen, c_hifen, c_hifen, c_enter,


### PR DESCRIPTION
## Issue
[#11](https://github.com/masaruohashi/tic-tac-toe/issues/11)

## Descrição
Modifica a memória de caracteres adicionando os caracteres necessários para limpar a tela do terminal.

## Objetivo
Fazer com que a tela do terminal seja limpa a cada nova jogada.

## Decisões
- contador_tabuleiro alterado para contar até 76.

- memoria_caractere alterado adicioanando os caracteres de controle de limpar a tela e posicionar o cursos no início da tela.

- mapeador_caractere alterado de acordo com as novas posições da memória.