### PR TITLE
add the modules to let a second player play the game in another computer

### DIFF
--- a/fluxo_dados_interface_jogo.vhd
+++ b/fluxo_dados_interface_jogo.vhd
@@ -5,17 +5,28 @@ use ieee.std_logic_1164.all;
 
 entity fluxo_dados_interface_jogo is
   port(
-    clock             : in  std_logic;
-    reset             : in  std_logic;
-    escreve_memoria   : in  std_logic;    -- habilita a escrita na memoria
-    recebe_dado       : in  std_logic;    -- habilita a recepção de dados na uart
-    imprime_tabuleiro : in  std_logic;    -- habilita o circuito de controle de impressao
-    entrada_serial    : in  std_logic;    -- entrada de dados do terminal para a uart
-    saida_serial      : out std_logic;    -- saida de dados da uart para o terminal
-    fim_impressao     : out std_logic;    -- indica o fim da impressao do tabuleiro no terminal
-    fim_recepcao      : out std_logic;    -- indica o fim da recepção de um caractere do terminal na uart
-    fim_jogo          : out std_logic;    -- indica que o jogo acabou por vitoria ou empate
-    jogada_ok         : out std_logic     -- indica que a jogada realizada é valida
+    clock                   : in  std_logic;
+    reset                   : in  std_logic;
+    jogador                 : in  std_logic;    -- sinaliza o jogador atual
+    transmite_dado_jogada   : in  std_logic;    -- habilita a transmissão da jogada para a outra bancada
+    escreve_memoria         : in  std_logic;    -- habilita a escrita na memoria
+    recebe_dado_jogador     : in  std_logic;    -- habilita a recepção de dados do terminal
+    recebe_dado_oponente    : in  std_logic;    -- habilita a recepção de dados da outra bancada
+    imprime_tabuleiro       : in  std_logic;    -- habilita o circuito de controle de impressao
+    entrada_serial          : in  std_logic;    -- entrada de dados do terminal para a uart
+    liga_modem              : in  std_logic;    -- habilita o modem para a troca de dados
+    CTS                     : in  std_logic;    -- Clear to Send
+    CD                      : in  std_logic;    -- Carrier Detect
+    RD                      : in  std_logic;    -- Received Data
+    DTR                     : out std_logic;    -- Data Transfer Ready
+    RTS                     : out std_logic;    -- Request to Send
+    TD                      : out std_logic;    -- Transmitted Data
+    saida_serial            : out std_logic;    -- saida de dados da uart para o terminal
+    fim_impressao           : out std_logic;    -- indica o fim da impressao do tabuleiro no terminal
+    fim_recepcao_jogador    : out std_logic;    -- indica o fim da recepção de um caractere do terminal na uart
+    fim_recepcao_oponente   : out std_logic;    -- indica o fim da recepção de um caractere da outra bancada na uart
+    fim_jogo                : out std_logic;    -- indica que o jogo acabou por vitoria ou empate
+    jogada_ok               : out std_logic     -- indica que a jogada realizada é valida
   );
 end fluxo_dados_interface_jogo;
 
@@ -106,24 +117,63 @@ architecture exemplo of fluxo_dados_interface_jogo is
     );
   end component;
 
+  component mapeador_jogador is
+  port(
+    jogador             : in std_logic;
+    caractere_jogador   : in std_logic_vector(6 downto 0);
+    caractere_oponente  : in std_logic_vector(6 downto 0);
+    caractere_saida     : out std_logic_vector(6 downto 0)
+  );
+  end component;
+
+  component interface_modem is
+    port(
+      clock              : in std_logic;
+      reset              : in std_logic;
+      liga               : in std_logic;
+      enviar             : in std_logic;
+      dadoSerial         : in std_logic;
+      CTS                : in std_logic;
+      CD                 : in std_logic;
+      RD                 : in std_logic;
+      DTR                : out std_logic;
+      RTS                : out std_logic;
+      TD                 : out std_logic;
+      envioOk            : out std_logic;
+      temDadoRecebido    : out std_logic;
+      dadoRecebido       : out std_logic
+    );
+  end component;
+
 signal s_endereco_leitura, s_endereco_escrita: std_logic_vector(5 downto 0);
-signal s_entrada_caractere, s_saida_caractere: std_logic_vector(6 downto 0);
+signal s_entrada_caractere, s_entrada_caractere_jogador, s_entrada_caractere_oponente, s_saida_caractere: std_logic_vector(6 downto 0);
 signal s_jogadas, s_jogador: std_logic_vector(8 downto 0);
 signal s_posicao: std_logic_vector(3 downto 0);
 signal s_jogador_atual: std_logic;
 signal s_uart_livre: std_logic;
-signal s_transmite_dado: std_logic;
+signal s_transmite_dado_tabuleiro, s_transmite_dado_jogada: std_logic;
 signal s_leitura_memoria: std_logic;
+signal s_saida_uart_modem: std_logic;
+signal s_entrada_serial_oponente: std_logic;
 
 begin
-
-  controle_impressao: controlador_impressao port map (clock, reset, imprime_tabuleiro, s_uart_livre, s_endereco_leitura, s_leitura_memoria, s_transmite_dado, fim_impressao);
-  memoria: memoria_caractere port map (clock, reset, s_leitura_memoria, escreve_memoria, s_endereco_leitura, s_endereco_escrita, s_saida_caractere, s_jogador_atual);
-  mapeador_char: mapeador_caractere port map (s_entrada_caractere, s_endereco_escrita);
-  uart_1: uart port map (clock, reset, entrada_serial, recebe_dado, s_transmite_dado, s_saida_caractere, saida_serial, s_entrada_caractere, fim_recepcao, open, s_uart_livre);
-  mapeador_jogo: mapeador_jogada port map (s_entrada_caractere, s_posicao);
-  jogada_valida: valida_jogada port map (s_entrada_caractere, s_jogadas, jogada_ok);
+  -- Jogadas e memória do tabuleiro
   jogadas: registrador_jogada port map (clock, reset, escreve_memoria, s_jogador_atual, s_posicao, s_jogadas, s_jogador);
+  memoria: memoria_caractere port map (clock, reset, s_leitura_memoria, escreve_memoria, s_endereco_leitura, s_endereco_escrita, s_saida_caractere, s_jogador_atual);
+  controle_impressao: controlador_impressao port map (clock, reset, imprime_tabuleiro, s_uart_livre, s_endereco_leitura, s_leitura_memoria, s_transmite_dado_tabuleiro, fim_impressao);
+
+  -- Mapeadores
+  mapeador_char: mapeador_caractere port map (s_entrada_caractere, s_endereco_escrita);
+  mapeador_jogo: mapeador_jogada port map (s_entrada_caractere, s_posicao);
+  mapeador_controle_jogo: mapeador_jogador port map (jogador, s_entrada_caractere_jogador, s_entrada_caractere_oponente, s_entrada_caractere);
+
+  -- Transmissão e recepção de dados
+  modem_uart: interface_modem port map (clock, reset, liga_modem, liga_modem, s_saida_uart_modem, CTS, CD, RD, DTR, RTS, TD, open, open, s_entrada_serial_oponente);
+  uart_jogador: uart port map (clock, reset, entrada_serial, recebe_dado_jogador, s_transmite_dado_tabuleiro, s_saida_caractere, saida_serial, s_entrada_caractere_jogador, fim_recepcao_jogador, open, s_uart_livre);
+  uart_oponente: uart port map (clock, reset, s_entrada_serial_oponente, recebe_dado_oponente, transmite_dado_jogada, s_entrada_caractere_jogador, s_saida_uart_modem, s_entrada_caractere_oponente, fim_recepcao_oponente, open, open);
+
+  -- Validação de dados e verificação de fim
+  jogada_valida: valida_jogada port map (s_entrada_caractere, s_jogadas, jogada_ok);
   final_jogo: verifica_fim port map (s_jogador_atual, s_jogadas, s_jogador, fim_jogo);
 
 end exemplo;

--- a/fluxo_dados_modem_recepcao.vhd
+++ b/fluxo_dados_modem_recepcao.vhd
@@ -1,0 +1,16 @@
+-- VHDL do Fluxo de Dados da recepção
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity fluxo_dados_modem_recepcao is
+  port(enableRecepcao : in std_Logic;
+       RD             : in std_logic;
+       dadoRecebido   : out std_logic);
+end fluxo_dados_modem_recepcao;
+
+architecture fluxo_dados of fluxo_dados_modem_recepcao is
+
+begin
+  dadoRecebido <= enableRecepcao and RD;
+end fluxo_dados;

--- a/fluxo_dados_modem_transmissao.vhd
+++ b/fluxo_dados_modem_transmissao.vhd
@@ -1,0 +1,16 @@
+-- VHDL do Fluxo de Dados da transmissão
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity fluxo_dados_modem_transmissao is
+  port(enableTransmissao: in  std_logic;
+       dadoSerial       : in  std_logic;
+       TD               : out std_logic);
+end fluxo_dados_modem_transmissao;
+
+architecture fluxo_dados of fluxo_dados_modem_transmissao is
+
+begin
+  TD <= enableTransmissao and dadoSerial;
+end fluxo_dados;

--- a/interface_modem.vhd
+++ b/interface_modem.vhd
@@ -1,0 +1,81 @@
+-- VHDL do Sistema Digital
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity interface_modem is
+  port(
+    clock              : in std_logic;
+    reset              : in std_logic;
+    liga               : in std_logic;    -- liga o circuito
+    enviar             : in std_logic;    -- sinal para habilitar o envio
+    dadoSerial         : in std_logic;    -- saida serial para os dados a serem enviados pelo modem
+    CTS                : in std_logic;    -- Clear To Send(0)
+    CD                 : in std_logic;    -- Carrier Detect(0)
+    RD                 : in std_logic;    -- Received Data(1)
+    DTR                : out std_logic;   -- Data Terminal Ready(0)
+    RTS                : out std_logic;   -- Request To Send(0)
+    TD                 : out std_logic;   -- Transmitted Data(1)
+    envioOk            : out std_logic;   -- Informa que os dados estão sendo enviados
+    temDadoRecebido    : out std_logic;   -- Informa que os dados estão sendo recebidos
+    dadoRecebido       : out std_logic    -- entrada serial para os dados recebidos
+  );
+end interface_modem;
+
+architecture interface of interface_modem is
+
+  component unidade_controle_modem_recepcao is
+    port(clock           : in   std_logic;
+         reset           : in   std_logic;
+         liga            : in   std_logic;
+         CD              : in   std_logic;
+         RD              : in   std_logic;
+         DTR             : out  std_logic;
+         temDadoRecebido : out  std_logic;
+         saida           : out  std_logic_vector(3 downto 0));  -- controle de estados
+  end component;
+
+  component unidade_controle_modem_transmissao is
+    port(clock      : in   std_logic;
+         reset      : in   std_logic;
+         liga       : in   std_logic;
+         enviar     : in   std_logic;
+         CTS        : in   std_logic;
+         DTR        : out  std_logic;
+         RTS        : out  std_logic;
+         envioOk    : out  std_logic;
+         saida      : out  std_logic_vector(3 downto 0));  -- controle de estados
+  end component;
+
+  component fluxo_dados_modem_transmissao is
+    port(enableTransmissao: in  std_logic;
+         dadoSerial       : in  std_logic;
+         TD               : out std_logic);
+  end component;
+
+  component fluxo_dados_modem_recepcao is
+    port(enableRecepcao : in std_Logic;
+         RD             : in std_logic;
+         dadoRecebido   : out std_logic);
+  end component;
+
+signal estadoRecepcao : std_logic_vector(3 downto 0);
+signal estadoTransmissao : std_logic_vector(3 downto 0);
+signal DTRRecepcao : std_logic;
+signal DTRTransmissao : std_logic;
+signal enableTransmissao : std_logic;
+signal enableRecepcao : std_logic;
+
+begin
+
+  uc_recepcao : unidade_controle_modem_recepcao port map (clock, reset, liga, CD, RD, DTRRecepcao, enableRecepcao, estadoRecepcao);
+  uc_transmissao : unidade_controle_modem_transmissao port map (clock, reset, liga, enviar, CTS, DTRTransmissao, RTS, enableTransmissao, estadoTransmissao);
+
+  fd_recepcao    : fluxo_dados_modem_recepcao port map (enableRecepcao, RD, dadoRecebido);
+  fd_transmissao : fluxo_dados_modem_transmissao port map (enableTransmissao, dadoSerial, TD);
+
+  DTR <= DTRRecepcao and DTRTransmissao;
+  envioOk <= enableTransmissao;
+  temDadoRecebido <= enableRecepcao;
+
+end interface;

--- a/jogo_velha.vhd
+++ b/jogo_velha.vhd
@@ -5,13 +5,20 @@ use ieee.std_logic_1164.all;
 
 entity jogo_velha is
   port(
-    clock: in std_logic;
-    reset: in std_logic;
-    entrada_serial: in std_logic;
-    start: in std_logic;
-    saida_serial: out std_logic;
-    fim: out std_logic;
-    dep_estados: out std_logic_vector(2 downto 0)
+    clock           : in std_logic;
+    reset           : in std_logic;
+    entrada_serial  : in std_logic;     -- entrada serial de dados do terminal
+    start           : in std_logic;     -- começo do jogo
+    primeiro        : in std_logic;     -- indica o primeiro jogador
+    CTS             : in  std_logic;    -- Clear to Send
+    CD              : in  std_logic;    -- Carrier Detect
+    RD              : in  std_logic;    -- Received Data
+    DTR             : out std_logic;    -- Data Transfer Ready
+    RTS             : out std_logic;    -- Request to Send
+    TD              : out std_logic;    -- Transmitted Data
+    saida_serial    : out std_logic;    -- saida serial de dados para o teminal
+    fim             : out std_logic;    -- fim do jogo
+    dep_estados     : out std_logic_vector(3 downto 0)
   );
 end jogo_velha;
 
@@ -19,44 +26,73 @@ architecture estrutural of jogo_velha is
 
   component unidade_controle_interface_jogo is
     port(
-      clock               : in std_logic;
-      reset               : in std_logic;
-      start               : in std_logic;
-      fim_impressao       : in std_logic;
-      fim_recepcao        : in std_logic;
-      jogada_ok           : in std_logic;
-      fim_jogo            : in std_logic;
-      imprime_tabuleiro   : out std_logic;
-      recebe_dado         : out std_logic;
-      insere_dado         : out std_logic;
-      jogo_acabado        : out std_logic;
-      dep_estados         : out std_logic_vector(2 downto 0)
+      clock                 : in std_logic;
+      reset                 : in std_logic;
+      start                 : in std_logic;
+      CTS                   : in std_logic;
+      CD                    : in std_logic;
+      primeiro              : in std_logic;
+      fim_impressao         : in std_logic;
+      fim_recepcao_jogador  : in std_logic;
+      fim_recepcao_oponente : in std_logic;
+      jogada_ok             : in std_logic;
+      fim_jogo              : in std_logic;
+      jogador               : out std_logic;
+      liga_modem            : out std_logic;
+      imprime_tabuleiro     : out std_logic;
+      envia_dados_jogador   : out std_logic;
+      recebe_dado_jogador   : out std_logic;
+      recebe_dado_oponente  : out std_logic;
+      insere_dado           : out std_logic;
+      jogo_acabado          : out std_logic;
+      dep_estados           : out std_logic_vector(3 downto 0)
     );
   end component;
 
   component fluxo_dados_interface_jogo is
     port(
-      clock             : in  std_logic;
-      reset             : in  std_logic;
-      escreve_memoria   : in  std_logic;
-      recebe_dado       : in  std_logic;
-      imprime_tabuleiro : in  std_logic;
-      entrada_serial    : in  std_logic;
-      saida_serial      : out std_logic;
-      fim_impressao     : out std_logic;
-      fim_recepcao      : out std_logic;
-      fim_jogo          : out std_logic;
-      jogada_ok         : out std_logic
+      clock                   : in  std_logic;
+      reset                   : in  std_logic;
+      jogador                 : in  std_logic;
+      transmite_dado_jogada   : in  std_logic;
+      escreve_memoria         : in  std_logic;
+      recebe_dado_jogador     : in  std_logic;
+      recebe_dado_oponente    : in  std_logic;
+      imprime_tabuleiro       : in  std_logic;
+      entrada_serial          : in  std_logic;
+      liga_modem              : in  std_logic;
+      CTS                     : in  std_logic;
+      CD                      : in  std_logic;
+      RD                      : in  std_logic;
+      DTR                     : out std_logic;
+      RTS                     : out std_logic;
+      TD                      : out std_logic;
+      saida_serial            : out std_logic;
+      fim_impressao           : out std_logic;
+      fim_recepcao_jogador    : out std_logic;
+      fim_recepcao_oponente   : out std_logic;
+      fim_jogo                : out std_logic;
+      jogada_ok               : out std_logic
     );
   end component;
 
-  signal s_fim_impressao, s_imprime_tabuleiro: std_logic;         -- relacionados a impressão do tabuleiro
-  signal s_fim_recepcao, s_recebe_dado, s_insere_dado: std_logic; -- relacionados a recepção do dado
-  signal s_fim_jogo, s_jogada_ok: std_logic;                      -- relacionados a validações/verificações
+  signal s_fim_impressao, s_imprime_tabuleiro, s_envia_dados_jogador: std_logic;  -- relacionados ao envio de dados pela uart
+  signal s_recebe_dado_jogador, s_recebe_dado_oponente, s_insere_dado: std_logic; -- relacionados a recepção do dado
+  signal s_fim_recepcao_jogador, s_fim_recepcao_oponente: std_logic;              -- relacionados ao fim da recepção
+  signal s_fim_jogo, s_jogada_ok: std_logic;                                      -- relacionados a validações/verificações
+  signal s_jogador: std_logic;                                                    -- relacionados ao jogador atual
+  signal s_liga_modem: std_logic;                                                 -- relacionados ao modem
 
 begin
 
-    unidade_controle : unidade_controle_interface_jogo port map (clock, reset, start, s_fim_impressao, s_fim_recepcao, s_jogada_ok, s_fim_jogo, s_imprime_tabuleiro, s_recebe_dado, s_insere_dado, fim, dep_estados);
-    fluxo_dados: fluxo_dados_interface_jogo port map(clock, reset, s_insere_dado, s_recebe_dado, s_imprime_tabuleiro, entrada_serial, saida_serial, s_fim_impressao, s_fim_recepcao, s_fim_jogo, s_jogada_ok);
+    unidade_controle : unidade_controle_interface_jogo port map (
+      clock, reset, start, CTS, CD, primeiro, s_jogador, s_fim_impressao, s_fim_recepcao_jogador, s_fim_recepcao_oponente, s_jogada_ok, s_fim_jogo,
+      s_liga_modem, s_imprime_tabuleiro, s_envia_dados_jogador, s_recebe_dado_jogador, s_recebe_dado_oponente, s_insere_dado, fim, dep_estados
+    );
+
+    fluxo_dados: fluxo_dados_interface_jogo port map(
+      clock, reset, s_jogador, s_envia_dados_jogador, s_insere_dado, s_recebe_dado_jogador, s_recebe_dado_oponente, s_imprime_tabuleiro, entrada_serial,
+      s_liga_modem, CTS, CD, RD, DTR, RTS, TD, saida_serial, s_fim_impressao, s_fim_recepcao_jogador, s_fim_recepcao_oponente, s_fim_jogo, s_jogada_ok
+    );
 
 end estrutural;

--- a/mapeador_jogador.vhd
+++ b/mapeador_jogador.vhd
@@ -1,0 +1,26 @@
+-- VHDL de um mapeador de caracteres
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity mapeador_jogador is
+  port(
+    jogador             : in std_logic;
+    caractere_jogador   : in std_logic_vector(6 downto 0);
+    caractere_oponente  : in std_logic_vector(6 downto 0);
+    caractere_saida     : out std_logic_vector(6 downto 0)
+  );
+end mapeador_jogador;
+
+architecture estrutural of mapeador_jogador is
+  signal sinal_caractere_saida: std_logic_vector(6 downto 0);
+begin
+  process (jogador)
+  begin
+    if jogador = '0' then
+      sinal_caractere_saida <= caractere_jogador;
+    else
+      sinal_caractere_saida <= caractere_oponente;
+    end if;
+    caractere_saida <= sinal_caractere_saida;
+  end process;
+end estrutural;

--- a/unidade_controle_interface_jogo.vhd
+++ b/unidade_controle_interface_jogo.vhd
@@ -5,23 +5,34 @@ use ieee.std_logic_1164.all;
 
 entity unidade_controle_interface_jogo is
   port(
-    clock               : in std_logic;
-    reset               : in std_logic;
-    start               : in std_logic;
-    fim_impressao       : in std_logic;   -- indica que o tabuleiro terminou de ser impresso
-    fim_recepcao        : in std_logic;   -- indica que um caractere terminou de ser recebido
-    jogada_ok           : in std_logic;   -- indica que o caractere recebido é valido
-    fim_jogo            : in std_logic;   -- indica que o jogo acabou
-    imprime_tabuleiro   : out std_logic;  -- habilita a impressao do tabuleiro
-    recebe_dado         : out std_logic;  -- habilita a recepção de um caractere do terminal
-    insere_dado         : out std_logic;  -- habilita a inserção do dado na memoria
-    jogo_acabado        : out std_logic;  -- indica que o jogo acabou
-    dep_estados         : out std_logic_vector(2 downto 0)
+    clock                 : in std_logic;
+    reset                 : in std_logic;
+    start                 : in std_logic;
+    CTS                   : in std_logic;   -- Clear to Send
+    CD                    : in std_logic;   -- Carrier Detect
+    primeiro              : in std_logic;   -- indica se o é o primeiro a jogar
+    fim_impressao         : in std_logic;   -- indica que o tabuleiro terminou de ser impresso
+    fim_recepcao_jogador  : in std_logic;   -- indica que um caractere terminou de ser recebido do terminal
+    fim_recepcao_oponente : in std_logic;   -- indica que um caractere terminou de ser recebido da outra bancada
+    jogada_ok             : in std_logic;   -- indica que o caractere recebido é valido
+    fim_jogo              : in std_logic;   -- indica que o jogo acabou
+    jogador               : out std_logic;  -- indica o jogador atual
+    liga_modem            : out std_logic;  -- habilita a interface do modem
+    imprime_tabuleiro     : out std_logic;  -- habilita a impressao do tabuleiro
+    envia_dados_jogador   : out std_logic;  -- habilita o envio da jogada para a outra bancada
+    recebe_dado_jogador   : out std_logic;  -- habilita a recepção de um caractere do terminal
+    recebe_dado_oponente  : out std_logic;  -- habilita a recepção de um caractere da outra bancada
+    insere_dado           : out std_logic;  -- habilita a inserção da jogada na memoria
+    jogo_acabado          : out std_logic;  -- indica que o jogo acabou
+    dep_estados           : out std_logic_vector(3 downto 0)
   );
 end unidade_controle_interface_jogo;
 
 architecture comportamental of unidade_controle_interface_jogo is
-type tipo_estado is (inicial, imprime, recebe, valida_jogada, guarda, valida_tabuleiro, final);
+type tipo_estado is (
+  inicial, prepara, imprime_oponente, recebe_jogador, valida_jogada, guarda_jogador,
+  envia_jogada, imprime_jogador, recebe_oponente, guarda_oponente, valida_tabuleiro, final
+);
 signal estado   : tipo_estado;
 
 begin
@@ -34,44 +45,75 @@ begin
     elsif (clock'event and clock = '1') then
       case estado is
         when inicial =>                -- Aguarda sinal de start
-          if start = '1' then
-            estado <= imprime;
-          else
+          if start = '0' then
             estado <= inicial;
-          end if;
-
-        when imprime =>                -- Imprime o tabuleiro no terminal
-          if fim_impressao = '1' then
-            estado <= recebe;
           else
-            estado <= imprime;
+            estado <= prepara;
           end if;
 
-        when recebe =>        -- Espera o dado ser recebido
-          if fim_recepcao = '1' then
+        when prepara =>                 -- Aguarda configuração do modem
+          if(CTS='0' and CD='0') then
+            if primeiro = '1' then
+              estado <= imprime_oponente;
+            else
+              estado <= imprime_jogador;
+            end if;
+          else
+            estado <= prepara;
+          end if;
+
+        when imprime_oponente =>                -- Imprime o tabuleiro no terminal
+          if fim_impressao = '1' then
+            estado <= recebe_jogador;
+          else
+            estado <= imprime_oponente;
+          end if;
+
+        when recebe_jogador =>        -- Espera o dado ser recebido
+          if fim_recepcao_jogador = '1' then
             estado <= valida_jogada;
           else
-            estado <= recebe;
+            estado <= recebe_jogador;
           end if;
 
-        when valida_jogada =>
+        when valida_jogada =>         -- Valida o caractere enviado do terminal
           if jogada_ok = '0' then
-            estado <= recebe;
+            estado <= recebe_jogador;
           else
-            estado <= guarda;
+            estado <= guarda_jogador;
           end if;
 
-        when guarda =>        -- Guarda o dado no tabuleiro
+        when guarda_jogador =>        -- Guarda o dado no tabuleiro
+          estado <= imprime_jogador;
+
+        when envia_jogada =>            -- Envia a jogada para a outra bancada
+          estado <= imprime_jogador;
+
+        when imprime_jogador =>      -- Imprime o tabuleiro no terminal
+          if fim_impressao = '1' then
+            estado <= recebe_oponente;
+          else
+            estado <= imprime_jogador;
+          end if;
+
+        when recebe_oponente =>         -- Recebe a jogada da outra bancada
+          if fim_recepcao_oponente = '1' then
+            estado <= guarda_oponente;
+          else
+            estado <= recebe_oponente;
+          end if;
+
+        when guarda_oponente =>         -- Guarda a jogada da outra bancada
           estado <= valida_tabuleiro;
 
-        when valida_tabuleiro =>
+        when valida_tabuleiro =>        -- Verifica se o jogo acabou
           if fim_jogo = '1' then
             estado <= final;
           else
-            estado <= imprime;
+            estado <= imprime_oponente;
           end if;
 
-        when final =>
+        when final =>                   -- Final do jogo
           estado <= final;
 
         when others =>       -- Default
@@ -82,38 +124,64 @@ begin
 
     -- logica de saída
     with estado select
-      imprime_tabuleiro <= '1' when imprime,
+      imprime_tabuleiro <= '1' when imprime_oponente | imprime_jogador,
                            '0' when others;
 
     with estado select
-      recebe_dado <= '1' when recebe,
-                     '0' when others;
+      recebe_dado_jogador <= '1' when recebe_jogador,
+                             '0' when others;
 
     with estado select
-      insere_dado <= '1' when guarda,
+      recebe_dado_oponente <= '1' when recebe_oponente,
+                              '0' when others;
+
+    with estado select
+      envia_dados_jogador <= '1' when envia_jogada,
+                             '0' when others;
+
+    with estado select
+      insere_dado <= '1' when guarda_jogador | guarda_oponente,
                      '0' when others;
 
     with estado select
       jogo_acabado <= '1' when final,
                       '0' when others;
 
+    with estado select
+      liga_modem <= '0' when inicial | final,
+                    '1' when others;
+
+    with estado select
+      jogador <= '0' when inicial | prepara | imprime_oponente | recebe_jogador | valida_jogada | guarda_jogador,
+                 '1' when others;
+
     process (estado)
     begin
       case estado is
         when inicial =>
-          dep_estados <= "000";
-        when imprime =>
-          dep_estados <= "010";
-        when recebe =>
-          dep_estados <= "011";
+          dep_estados <= "0000";
+        when prepara =>
+          dep_estados <= "1111";
+        when imprime_oponente =>
+          dep_estados <= "0001";
+        when recebe_jogador =>
+          dep_estados <= "0010";
         when valida_jogada =>
-          dep_estados <= "100";
-        when guarda =>
-          dep_estados <= "101";
+          dep_estados <= "0011";
+        when guarda_jogador =>
+          dep_estados <= "0100";
+        when imprime_jogador =>
+          dep_estados <= "0101";
+        when envia_jogada =>
+          dep_estados <= "0110";
+        when recebe_oponente =>
+          dep_estados <= "0111";
+        when guarda_oponente =>
+          dep_estados <= "1000";
         when valida_tabuleiro =>
-          dep_estados <= "110";
+          dep_estados <= "1001";
         when final =>
-          dep_estados <= "111";
+          dep_estados <= "1010";
         when others =>
           null;
       end case;

--- a/unidade_controle_modem_recepcao.vhd
+++ b/unidade_controle_modem_recepcao.vhd
@@ -1,0 +1,77 @@
+-- VHDL da Unidade de Controle da transmissão
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity unidade_controle_modem_recepcao is
+   port(clock           : in   std_logic;
+        reset           : in   std_logic;
+        liga            : in   std_logic;
+        CD              : in   std_logic;
+        RD              : in   std_logic;
+        DTR             : out  std_logic;
+        temDadoRecebido : out  std_logic;
+        saida           : out  std_logic_vector(3 downto 0));  -- controle de estados
+end unidade_controle_modem_recepcao;
+
+architecture unidade_controle of unidade_controle_modem_recepcao is
+type tipo_estado is (inicial, recepcao, final, desabilitado);
+signal estado   : tipo_estado;
+
+begin
+  process (clock, estado, reset)
+  begin
+
+    if liga = '0' then
+      estado <= desabilitado;
+    elsif reset = '1' then
+      estado <= inicial;
+
+    elsif (clock'event and clock = '1') then
+      case estado is
+      when inicial =>      -- Aguarda sinal de inicio
+        if CD = '0' then   -- Ativo em baixo
+          estado <= recepcao;
+        end if;
+
+      when recepcao =>   -- Recebe o sinal do modem
+        if CD = '1' then   -- Ativo em baixo
+          estado <= final;
+        end if;
+
+      when final =>      -- Aguarda desativação do sinal RD
+        if RD = '1' then   -- Ativo em baixo
+          estado <= inicial;
+        end if;
+
+      when desabilitado =>         -- Circuito desabilitado
+        if liga = '1' then
+          estado <= inicial;
+        end if;
+
+      end case;
+    end if;
+  end process;
+
+  process (estado)
+  begin
+    case estado is
+      when inicial =>
+        DTR <= '0';
+        saida <= "0000";
+        temDadoRecebido <= '0';
+      when recepcao =>
+        DTR <= '0';
+        saida <= "0001";
+        temDadoRecebido <= '1';
+      when final =>
+        DTR <= '0';
+        saida <= "0010";
+        temDadoRecebido <= '0';
+      when desabilitado =>
+        DTR <= '1';
+        saida <= "1111";
+        temDadoRecebido <= '0';
+    end case;
+   end process;
+end unidade_controle;

--- a/unidade_controle_modem_transmissao.vhd
+++ b/unidade_controle_modem_transmissao.vhd
@@ -1,0 +1,92 @@
+-- VHDL da Unidade de Controle da transmissão
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity unidade_controle_modem_transmissao is
+   port(clock      : in   std_logic;
+        reset      : in   std_logic;
+        liga       : in   std_logic;
+        enviar     : in   std_logic;
+        CTS        : in   std_logic;
+        DTR        : out  std_logic;
+        RTS        : out  std_logic;
+        envioOk    : out  std_logic;
+        saida      : out  std_logic_vector(3 downto 0));  -- controle de estados
+end unidade_controle_modem_transmissao;
+
+architecture unidade_controle of unidade_controle_modem_transmissao is
+type tipo_estado is (inicial, preparacao, transmissao, desabilitado, final);
+signal estado   : tipo_estado;
+
+begin
+  process (clock, estado, reset)
+  begin
+
+    if liga = '0' then
+      estado <= desabilitado;
+    elsif reset = '1' then
+      estado <= inicial;
+
+    elsif (clock'event and clock = '1') then
+      case estado is
+      when inicial =>      -- Aguarda sinal de inicio
+        if enviar = '1' then
+          estado <= preparacao;
+        end if;
+
+      when preparacao =>    -- Espera sinal de controle CTS do modem
+        if CTS = '0' then   -- Ativo em baixo
+          estado <= transmissao;
+        end if;
+
+      when transmissao =>    -- Envia o que estiver na entrada de dados
+        if enviar = '0' then
+          estado <= final;
+        end if;
+
+      when final =>         -- Fim da transmissao serial
+        if CTS = '1' then
+          estado <= inicial;
+        end if;
+
+      when desabilitado =>         -- Circuito desabilitado
+        if liga = '1' then
+          estado <= inicial;
+        end if;
+
+      end case;
+    end if;
+  end process;
+
+  process (estado)
+  begin
+    case estado is
+      when inicial =>
+        saida <= "0000";
+        envioOk <= '0';
+        DTR <= '0';
+        RTS <= '1';
+      when preparacao =>
+        saida <= "0001";
+        envioOk <= '0';
+        DTR <= '0';
+        RTS <= '0';
+      when transmissao =>
+        saida <= "0010";
+        envioOk <= '1';
+        DTR <= '0';
+        RTS <= '0';
+      when final =>
+        saida <= "0011";
+        envioOk <= '0';
+        DTR <= '0';
+        RTS <= '1';
+      when desabilitado =>
+        saida <= "1111";
+        envioOk <= '0';
+        DTR <= '1';
+        RTS <= '1';
+    end case;
+   end process;
+end unidade_controle;


### PR DESCRIPTION
## Issue
#13 

## Descrição
Permite que um outro jogador jogue o jogo da velha em outra bancada

## Objetivo
Adicionar os módulos para permitir que um outro jogador, além da interface com o modem

## Decisões
*  Adicionei uma nova uart e o projeto da ex4(interface com modem)
*  Criei um mapeador para os dados a serem gravados na memoria, de acordo com o jogador atual
*  Adicionei novos estados para transmitir e receber a jogada para o oponente

