### PR TITLE
Send data to the other player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 !uart
 !logica_jogo
 !interface_jogo
+!interface_modem
 
 # Allow the gitignore file
 !*.gitignore

--- a/interface_jogo/fluxo_dados_interface_jogo.vhd
+++ b/interface_jogo/fluxo_dados_interface_jogo.vhd
@@ -5,17 +5,27 @@ use ieee.std_logic_1164.all;
 
 entity fluxo_dados_interface_jogo is
   port(
-    clock             : in  std_logic;
-    reset             : in  std_logic;
-    jogador_atual     : in  std_logic;                     -- indica o jogador atual do jogo da velha
-    escreve_memoria   : in  std_logic;                     -- habilita a escrita na memoria
-    recebe_dado       : in  std_logic;                     -- habilita a recepção de dados na uart
-    imprime_tabuleiro : in  std_logic;                     -- habilita o circuito de controle de impressao
-    entrada_serial    : in  std_logic;                     -- entrada de dados do terminal para a uart
-    saida_serial      : out std_logic;                     -- saida de dados da uart para o terminal
-    fim_impressao     : out std_logic;                     -- indica o fim da impressao do tabuleiro no terminal
-    fim_recepcao      : out std_logic;                     -- indica o fim da recepção de um caractere do terminal na uart
-    dado_paralelo     : out std_logic_vector(6 downto 0)   -- dados a serem verificados pela logica 
+    clock                   : in  std_logic;
+    reset                   : in  std_logic;
+    jogador_atual           : in  std_logic;                     -- indica o jogador atual do jogo da velha
+    escreve_memoria         : in  std_logic;                     -- habilita a escrita na memoria
+    recebe_dado_jogador     : in  std_logic;                     -- habilita a recepção de dados do jogador na uart
+    imprime_tabuleiro       : in  std_logic;                     -- habilita o circuito de controle de impressao
+    liga_modem              : in  std_logic;                     -- liga a interface do modem para a comunicação com a outra bancada
+    envia_dado              : in  std_logic;                     -- habilita o envio de dados para a outra bancada
+    entrada_serial_jogador  : in  std_logic;                     -- entrada de dados do terminal para a uart
+    CTS                     : in  std_logic;                     -- Clear to send
+    CD                      : in  std_logic;                     -- Carrier Detect
+    RD                      : in  std_logic;                     -- Received Data
+    DTR                     : out std_logic;                     -- Data transfer Ready
+    RTS                     : out std_logic;                     -- Request to send
+    TD                      : out std_logic;                     -- Transmitted data
+    saida_serial_tabuleiro  : out std_logic;                     -- saida de dados da uart para o terminal
+    fim_impressao           : out std_logic;                     -- indica o fim da impressao do tabuleiro no terminal
+    fim_transmissao         : out std_logic;                     -- indica o fim da tranmissao do dado para a outra bancada
+    fim_recepcao_jogador    : out std_logic;                     -- indica o fim da recepção de um caractere do terminal na uart do jogador
+    fim_recepcao_oponente   : out std_logic;                     -- indica o fim da recepção de um caractere do terminal na uart do oponente
+    dado_paralelo           : out std_logic_vector(6 downto 0)   -- dados a serem verificados pela logica
   );
 end fluxo_dados_interface_jogo;
 
@@ -70,19 +80,54 @@ architecture exemplo of fluxo_dados_interface_jogo is
     );
   end component;
 
+  component interface_modem is
+    port(
+      clock              : in  std_logic;
+      reset              : in  std_logic;
+      liga               : in  std_logic;
+      enviar             : in  std_logic;
+      dadoSerial         : in  std_logic;
+      CTS                : in  std_logic;
+      CD                 : in  std_logic;
+      RD                 : in  std_logic;
+      DTR                : out std_logic;
+      RTS                : out std_logic;
+      TD                 : out std_logic;
+      envioOk            : out  std_logic;
+      temDadoRecebido    : out  std_logic;
+      dadoRecebido       : out  std_logic
+    );
+  end component;
+
+  component mapeador_entrada_caractere is
+    port(
+      jogador: in std_logic_vector(6 downto 0);
+      oponente: in std_logic_vector(6 downto 0);
+      jogador_atual: in std_logic;
+      entrada_caractere: out std_logic_vector(6 downto 0)
+    );
+  end component;
+
 signal s_endereco_leitura, s_endereco_escrita: std_logic_vector(6 downto 0);
-signal s_entrada_caractere, s_saida_caractere: std_logic_vector(6 downto 0);
+signal s_entrada_caractere, s_entrada_caractere_jogador, s_entrada_caractere_oponente, s_saida_caractere: std_logic_vector(6 downto 0);
 signal s_jogador_atual: std_logic;
 signal s_uart_livre: std_logic;
 signal s_transmite_dado: std_logic;
 signal s_leitura_memoria: std_logic;
+signal s_entrada_serial_oponente: std_logic;
+signal s_recebe_dado_oponente: std_logic;
+signal s_envia_dado_oponente: std_logic;
+signal s_saida_serial_jogada: std_logic;
 
 begin
 
   controle_impressao: controlador_impressao port map (clock, reset, imprime_tabuleiro, s_uart_livre, s_endereco_leitura, s_leitura_memoria, s_transmite_dado, fim_impressao);
   memoria: memoria_caractere port map (clock, reset, s_leitura_memoria, escreve_memoria, jogador_atual, s_endereco_leitura, s_endereco_escrita, s_saida_caractere);
   mapeador_char: mapeador_caractere port map (s_entrada_caractere, s_endereco_escrita);
-  uart_jogador: uart port map (clock, reset, entrada_serial, recebe_dado, s_transmite_dado, s_saida_caractere, saida_serial, s_entrada_caractere, fim_recepcao, open, s_uart_livre);
+  uart_jogador: uart port map (clock, reset, entrada_serial_jogador, recebe_dado_jogador, s_transmite_dado, s_saida_caractere, saida_serial_tabuleiro, s_entrada_caractere_jogador, fim_recepcao_jogador, open, s_uart_livre);
+  mapeia_entrada_caractere: mapeador_entrada_caractere port map (s_entrada_caractere_jogador, s_entrada_caractere_oponente, jogador_atual, s_entrada_caractere);
+  uart_oponente: uart port map (clock, reset, s_entrada_serial_oponente, s_recebe_dado_oponente, s_envia_dado_oponente, s_entrada_caractere_jogador, s_saida_serial_jogada, s_entrada_caractere_oponente, fim_recepcao_oponente, open, fim_transmissao);
+  modem_interface: interface_modem port map (clock, reset, liga_modem, envia_dado, s_saida_serial_jogada, CTS, CD, RD, DTR, RTS, TD, s_envia_dado_oponente, s_recebe_dado_oponente, s_entrada_serial_oponente);
 
   dado_paralelo <= s_entrada_caractere;
 

--- a/interface_jogo/interface_jogo.vhd
+++ b/interface_jogo/interface_jogo.vhd
@@ -8,10 +8,17 @@ entity interface_jogo is
     clock                 : in std_logic;
     reset                 : in std_logic;
     start                 : in std_logic;
+    jogador               : in std_logic;
     fim_recepcao          : in std_logic;
     recebe_dado           : in std_logic;
     guarda_dado           : in std_logic;
     entrada_serial        : in std_logic;
+    CTS                   : in std_logic;
+    CD                    : in std_logic;
+    RD                    : in std_logic;
+    DTR                   : out std_logic;
+    RTS                   : out std_logic;
+    TD                    : out std_logic;
     jogador_atual         : out std_logic;
     saida_serial          : out std_logic;
     habilita_logica       : out std_logic;
@@ -28,39 +35,57 @@ architecture estrutural of interface_jogo is
       clock               : in std_logic;
       reset               : in std_logic;
       start               : in std_logic;
-      fim_impressao       : in std_logic;
-      fim_recepcao        : in std_logic;
-      imprime_tabuleiro   : out std_logic;
-      recebe_dado         : out std_logic;
-      jogador_atual       : out std_logic;
+      jogador             : in std_logic;   -- indica se o jogador é o primeiro a jogar ou o segundo
+      fim_impressao       : in std_logic;   -- indica que o tabuleiro terminou de ser impresso
+      fim_recepcao        : in std_logic;   -- indica que um caractere terminou de ser recebido
+      fim_transmissao     : in std_logic;   -- indica que um caractere terminou de ser eniado para a outra bancada
+      liga_modem          : out std_logic;   -- indica que a interface do modem deve ser ligada
+      imprime_tabuleiro   : out std_logic;  -- habilita a impressao do tabuleiro
+      envia_jogada        : out std_logic;  -- habilita o envio da jogada para a outra bancada
+      recebe_dado         : out std_logic;  -- habilita a recepção de um caractere do terminal
+      jogador_atual       : out std_logic;  -- indica o jogador atual do jogo da velha
       dep_estados         : out std_logic_vector(2 downto 0)
     );
   end component;
 
   component fluxo_dados_interface_jogo is
     port(
-      clock             : in  std_logic;
-      reset             : in  std_logic;
-      jogador_atual     : in  std_logic;
-      escreve_memoria   : in  std_logic;
-      recebe_dado       : in  std_logic;
-      imprime_tabuleiro : in  std_logic;
-      entrada_serial    : in  std_logic;
-      saida_serial      : out std_logic;
-      fim_impressao     : out std_logic;
-      fim_recepcao      : out std_logic;
-      dado_paralelo     : out std_logic_vector(6 downto 0) 
+      clock                   : in  std_logic;
+      reset                   : in  std_logic;
+      jogador_atual           : in  std_logic;                     -- indica o jogador atual do jogo da velha
+      escreve_memoria         : in  std_logic;                     -- habilita a escrita na memoria
+      recebe_dado_jogador     : in  std_logic;                     -- habilita a recepção de dados do jogador na uart
+      imprime_tabuleiro       : in  std_logic;                     -- habilita o circuito de controle de impressao
+      liga_modem              : in  std_logic;                     -- liga a interface do modem para a comunicação com a outra bancada
+      envia_dado              : in  std_logic;                     -- habilita o envio de dados para a outra bancada
+      entrada_serial_jogador  : in  std_logic;                     -- entrada de dados do terminal para a uart
+      CTS                     : in  std_logic;                     -- Clear to send
+      CD                      : in  std_logic;                     -- Carrier Detect
+      RD                      : in  std_logic;                     -- Received Data
+      DTR                     : out std_logic;                     -- Data transfer Ready
+      RTS                     : out std_logic;                     -- Request to send
+      TD                      : out std_logic;                     -- Transmitted data
+      saida_serial_tabuleiro  : out std_logic;                     -- saida de dados da uart para o terminal
+      fim_impressao           : out std_logic;                     -- indica o fim da impressao do tabuleiro no terminal
+      fim_transmissao         : out std_logic;                     -- indica o fim da tranmissao do dado para a outra bancada
+      fim_recepcao_jogador    : out std_logic;                     -- indica o fim da recepção de um caractere do terminal na uart do jogador
+      fim_recepcao_oponente   : out std_logic;                     -- indica o fim da recepção de um caractere do terminal na uart do oponente
+      dado_paralelo           : out std_logic_vector(6 downto 0)   -- dados a serem verificados pela logica
     );
   end component;
 
   signal s_fim_impressao, s_imprime_tabuleiro: std_logic;
   signal s_jogador_atual: std_logic;
+  signal s_fim_recepcao_jogador, s_fim_recepcao_oponente: std_logic;
+  signal s_liga_modem, s_envia_jogada: std_logic;
+  signal s_fim_transmissao: std_logic; 
 
 begin
 
-  UC: unidade_controle_interface_jogo port map (clock, reset, start, s_fim_impressao, fim_recepcao, s_imprime_tabuleiro, habilita_logica, s_jogador_atual, estados);
-  FD: fluxo_dados_interface_jogo port map(clock, reset, s_jogador_atual, guarda_dado, recebe_dado, s_imprime_tabuleiro, entrada_serial, saida_serial, s_fim_impressao, habilita_verificacao, dado_paralelo);
+  UC: unidade_controle_interface_jogo port map (clock, reset, start, jogador, s_fim_impressao, fim_recepcao, s_fim_transmissao, s_liga_modem, s_imprime_tabuleiro, s_envia_jogada, habilita_logica, s_jogador_atual, estados);
+  FD: fluxo_dados_interface_jogo port map(clock, reset, s_jogador_atual, guarda_dado, recebe_dado, s_imprime_tabuleiro, s_liga_modem, s_envia_jogada, entrada_serial, CTS, CD, RD, DTR, RTS, TD, saida_serial, s_fim_impressao, s_fim_transmissao, s_fim_recepcao_jogador, s_fim_recepcao_oponente, dado_paralelo);
 
   jogador_atual <= s_jogador_atual;
+  habilita_verificacao <= s_fim_recepcao_jogador or s_fim_recepcao_oponente;
 
 end estrutural;

--- a/interface_jogo/interface_jogo.vhd
+++ b/interface_jogo/interface_jogo.vhd
@@ -13,6 +13,7 @@ entity interface_jogo is
     recebe_dado           : in std_logic;
     guarda_dado           : in std_logic;
     entrada_serial        : in std_logic;
+    fim_jogo              : in std_logic;
     CTS                   : in std_logic;
     CD                    : in std_logic;
     RD                    : in std_logic;
@@ -39,7 +40,8 @@ architecture estrutural of interface_jogo is
       fim_impressao       : in std_logic;   -- indica que o tabuleiro terminou de ser impresso
       fim_recepcao        : in std_logic;   -- indica que um caractere terminou de ser recebido
       fim_transmissao     : in std_logic;   -- indica que um caractere terminou de ser eniado para a outra bancada
-      liga_modem          : out std_logic;   -- indica que a interface do modem deve ser ligada
+      fim_jogo            : in std_logic;   -- indica que o jogo acabou
+      liga_modem          : out std_logic;  -- indica que a interface do modem deve ser ligada
       imprime_tabuleiro   : out std_logic;  -- habilita a impressao do tabuleiro
       envia_jogada        : out std_logic;  -- habilita o envio da jogada para a outra bancada
       recebe_dado         : out std_logic;  -- habilita a recepção de um caractere do terminal
@@ -82,7 +84,7 @@ architecture estrutural of interface_jogo is
 
 begin
 
-  UC: unidade_controle_interface_jogo port map (clock, reset, start, jogador, s_fim_impressao, fim_recepcao, s_fim_transmissao, s_liga_modem, s_imprime_tabuleiro, s_envia_jogada, habilita_logica, s_jogador_atual, estados);
+  UC: unidade_controle_interface_jogo port map (clock, reset, start, jogador, s_fim_impressao, fim_recepcao, s_fim_transmissao, fim_jogo, s_liga_modem, s_imprime_tabuleiro, s_envia_jogada, habilita_logica, s_jogador_atual, estados);
   FD: fluxo_dados_interface_jogo port map(clock, reset, s_jogador_atual, guarda_dado, recebe_dado, s_imprime_tabuleiro, s_liga_modem, s_envia_jogada, entrada_serial, CTS, CD, RD, DTR, RTS, TD, saida_serial, s_fim_impressao, s_fim_transmissao, s_fim_recepcao_jogador, s_fim_recepcao_oponente, dado_paralelo);
 
   jogador_atual <= s_jogador_atual;

--- a/interface_jogo/mapeador_entrada_caractere.vhd
+++ b/interface_jogo/mapeador_entrada_caractere.vhd
@@ -1,0 +1,24 @@
+-- VHDL de um mapeador entrada de caractere paralelo
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity mapeador_entrada_caractere is
+  port(
+    jogador: in std_logic_vector(6 downto 0);
+    oponente: in std_logic_vector(6 downto 0);
+    jogador_atual: in std_logic;
+    entrada_caractere: out std_logic_vector(6 downto 0)
+  );
+end mapeador_entrada_caractere;
+
+architecture estrutural of mapeador_entrada_caractere is
+begin
+  process (jogador_atual)
+  begin
+    if jogador_atual='0' then
+      entrada_caractere <= jogador;
+    else
+      entrada_caractere <= oponente;
+    end if;
+  end process;
+end estrutural;

--- a/interface_jogo/unidade_controle_interface_jogo.vhd
+++ b/interface_jogo/unidade_controle_interface_jogo.vhd
@@ -8,9 +8,13 @@ entity unidade_controle_interface_jogo is
     clock               : in std_logic;
     reset               : in std_logic;
     start               : in std_logic;
+    jogador             : in std_logic;   -- indica se o jogador é o primeiro a jogar ou o segundo
     fim_impressao       : in std_logic;   -- indica que o tabuleiro terminou de ser impresso
     fim_recepcao        : in std_logic;   -- indica que um caractere terminou de ser recebido
+    fim_transmissao     : in std_logic;   -- indica que um caractere terminou de ser eniado para a outra bancada
+    liga_modem          : out std_logic;   -- indica que a interface do modem deve ser ligada
     imprime_tabuleiro   : out std_logic;  -- habilita a impressao do tabuleiro
+    envia_jogada        : out std_logic;  -- habilita o envio da jogada para a outra bancada
     recebe_dado         : out std_logic;  -- habilita a recepção de um caractere do terminal
     jogador_atual       : out std_logic;  -- indica o jogador atual do jogo da velha
     dep_estados         : out std_logic_vector(2 downto 0)
@@ -18,7 +22,7 @@ entity unidade_controle_interface_jogo is
 end unidade_controle_interface_jogo;
 
 architecture comportamental of unidade_controle_interface_jogo is
-type tipo_estado is (inicial, imprime, recebe, valida_jogada, guarda, valida_tabuleiro, final);
+type tipo_estado is (inicial, imprime_oponente, recebe_jogador, envia_caractere, imprime_jogador, recebe_oponente);
 signal estado   : tipo_estado;
 
 begin
@@ -32,23 +36,48 @@ begin
       case estado is
         when inicial =>                -- Aguarda sinal de start
           if start = '1' then
-            estado <= imprime;
+            if jogador='0' then
+              estado <= imprime_oponente;
+            else
+              estado <= imprime_jogador;
+            end if;
           else
             estado <= inicial;
           end if;
 
-        when imprime =>                -- Imprime o tabuleiro no terminal
+        when imprime_oponente =>                -- Imprime o tabuleiro no terminal
           if fim_impressao = '1' then
-            estado <= recebe;
+            estado <= recebe_jogador;
           else
-            estado <= imprime;
+            estado <= imprime_oponente;
           end if;
 
-        when recebe =>        -- Espera o dado ser recebido
+        when recebe_jogador =>        -- Espera o dado ser recebido do terminal
           if fim_recepcao = '1' then
-            estado <= imprime;
+            estado <= envia_caractere;
           else
-            estado <= recebe;
+            estado <= recebe_jogador;
+          end if;
+
+        when envia_caractere =>
+          if fim_transmissao = '1' then
+            estado <= imprime_jogador;
+          else
+            estado <= envia_caractere;
+        end if;
+
+        when imprime_jogador =>                -- Imprime o tabuleiro no terminal
+          if fim_impressao = '1' then
+            estado <= recebe_oponente;
+          else
+            estado <= imprime_jogador;
+          end if;
+
+        when recebe_oponente =>        -- Espera o dado ser recebido da outra bancada
+          if fim_recepcao = '1' then
+            estado <= imprime_oponente;
+          else
+            estado <= recebe_jogador;
           end if;
 
         when others =>       -- Default
@@ -59,28 +88,34 @@ begin
 
     -- logica de saída
     with estado select
-      imprime_tabuleiro <= '1' when imprime,
+      imprime_tabuleiro <= '1' when imprime_oponente | imprime_jogador,
                            '0' when others;
 
     with estado select
-      recebe_dado <= '1' when recebe,
+      recebe_dado <= '1' when recebe_jogador | recebe_oponente,
                      '0' when others;
 
     with estado select
-      jogador_atual <= '0' when recebe | guarda,
-                       '1' when others;
+      envia_jogada <= '1' when envia_caractere,
+                      '0' when others;
+
+    with estado select
+      jogador_atual <= '1' when imprime_oponente | recebe_oponente,
+                       '0' when others;
+
+    with estado select
+      liga_modem <= '1' when envia_caractere | recebe_oponente,
+                    '0' when others;
 
     process (estado)
     begin
       case estado is
         when inicial =>
           dep_estados <= "000";
-        when imprime =>
+        when imprime_oponente =>
           dep_estados <= "010";
-        when recebe =>
+        when recebe_jogador =>
           dep_estados <= "011";
-        when final =>
-          dep_estados <= "111";
         when others =>
           null;
       end case;

--- a/interface_modem/fluxo_dados_modem_recepcao.vhd
+++ b/interface_modem/fluxo_dados_modem_recepcao.vhd
@@ -1,0 +1,16 @@
+-- VHDL do Fluxo de Dados da recepção
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity fluxo_dados_modem_recepcao is
+  port(enableRecepcao : in std_Logic;
+       RD             : in std_logic;
+       dadoRecebido   : out std_logic);
+end fluxo_dados_modem_recepcao;
+
+architecture fluxo_dados of fluxo_dados_modem_recepcao is
+
+begin
+  dadoRecebido <= enableRecepcao and RD;
+end fluxo_dados;

--- a/interface_modem/fluxo_dados_modem_transmissao.vhd
+++ b/interface_modem/fluxo_dados_modem_transmissao.vhd
@@ -1,0 +1,16 @@
+-- VHDL do Fluxo de Dados da transmissão
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity fluxo_dados_modem_transmissao is
+  port(enableTransmissao: in  std_logic;
+       dadoSerial       : in  std_logic;
+       TD               : out std_logic);
+end fluxo_dados_modem_transmissao;
+
+architecture fluxo_dados of fluxo_dados_modem_transmissao is
+
+begin
+  TD <= enableTransmissao and dadoSerial;
+end fluxo_dados;

--- a/interface_modem/interface_modem.vhd
+++ b/interface_modem/interface_modem.vhd
@@ -1,0 +1,79 @@
+-- VHDL do Sistema Digital
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity interface_modem is
+  port(clock              : in  std_logic;
+       reset              : in  std_logic;
+       liga               : in  std_logic;
+       enviar             : in  std_logic;
+       dadoSerial         : in  std_logic;
+       CTS                : in  std_logic;
+       CD                 : in  std_logic;
+       RD                 : in  std_logic;
+       DTR                : out std_logic;
+       RTS                : out std_logic;
+       TD                 : out std_logic;
+       envioOk            : out  std_logic;
+       temDadoRecebido    : out  std_logic;
+       dadoRecebido       : out  std_logic);
+end interface_modem;
+
+architecture interface of interface_modem is
+
+  component unidade_controle_modem_recepcao is
+    port(clock           : in   std_logic;
+         reset           : in   std_logic;
+         liga            : in   std_logic;
+         CD              : in   std_logic;
+         RD              : in   std_logic;
+         DTR             : out  std_logic;
+         temDadoRecebido : out  std_logic;
+         saida           : out  std_logic_vector(3 downto 0));  -- controle de estados
+  end component;
+
+  component unidade_controle_modem_transmissao is
+    port(clock      : in   std_logic;
+         reset      : in   std_logic;
+         liga       : in   std_logic;
+         enviar     : in   std_logic;
+         CTS        : in   std_logic;
+         DTR        : out  std_logic;
+         RTS        : out  std_logic;
+         envioOk    : out  std_logic;
+         saida      : out  std_logic_vector(3 downto 0));  -- controle de estados
+  end component;
+
+  component fluxo_dados_modem_transmissao is
+    port(enableTransmissao: in  std_logic;
+         dadoSerial       : in  std_logic;
+         TD               : out std_logic);
+  end component;
+
+  component fluxo_dados_modem_recepcao is
+    port(enableRecepcao : in std_Logic;
+         RD             : in std_logic;
+         dadoRecebido   : out std_logic);
+  end component;
+
+signal estadoRecepcao : std_logic_vector(3 downto 0);
+signal estadoTransmissao : std_logic_vector(3 downto 0);
+signal DTRRecepcao : std_logic;
+signal DTRTransmissao : std_logic;
+signal enableTransmissao : std_logic;
+signal enableRecepcao : std_logic;
+
+begin
+
+  uc_recepcao : unidade_controle_modem_recepcao port map (clock, reset, liga, CD, RD, DTRRecepcao, enableRecepcao, estadoRecepcao);
+  uc_transmissao : unidade_controle_modem_transmissao port map (clock, reset, liga, enviar, CTS, DTRTransmissao, RTS, enableTransmissao, estadoTransmissao);
+
+  fd_recepcao    : fluxo_dados_modem_recepcao port map (enableRecepcao, RD, dadoRecebido);
+  fd_transmissao : fluxo_dados_modem_transmissao port map (enableTransmissao, dadoSerial, TD);
+
+  DTR <= DTRRecepcao and DTRTransmissao;
+  envioOk <= enableTransmissao;
+  temDadoRecebido <= enableRecepcao;
+
+end interface;

--- a/interface_modem/unidade_controle_modem_recepcao.vhd
+++ b/interface_modem/unidade_controle_modem_recepcao.vhd
@@ -1,0 +1,77 @@
+-- VHDL da Unidade de Controle da transmissão
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity unidade_controle_modem_recepcao is
+   port(clock           : in   std_logic;
+        reset           : in   std_logic;
+        liga            : in   std_logic;
+        CD              : in   std_logic;
+        RD              : in   std_logic;
+        DTR             : out  std_logic;
+        temDadoRecebido : out  std_logic;
+        saida           : out  std_logic_vector(3 downto 0));  -- controle de estados
+end unidade_controle_modem_recepcao;
+
+architecture unidade_controle of unidade_controle_modem_recepcao is
+type tipo_estado is (inicial, recepcao, final, desabilitado);
+signal estado   : tipo_estado;
+
+begin
+  process (clock, estado, reset)
+  begin
+
+    if liga = '0' then
+      estado <= desabilitado;
+    elsif reset = '1' then
+      estado <= inicial;
+
+    elsif (clock'event and clock = '1') then
+      case estado is
+      when inicial =>      -- Aguarda sinal de inicio
+        if CD = '0' then   -- Ativo em baixo
+          estado <= recepcao;
+        end if;
+
+      when recepcao =>   -- Recebe o sinal do modem
+        if CD = '1' then   -- Ativo em baixo
+          estado <= final;
+        end if;
+
+      when final =>      -- Aguarda desativação do sinal RD
+        if RD = '1' then   -- Ativo em baixo
+          estado <= inicial;
+        end if;
+
+      when desabilitado =>         -- Circuito desabilitado
+        if liga = '1' then
+          estado <= inicial;
+        end if;
+
+      end case;
+    end if;
+  end process;
+
+  process (estado)
+  begin
+    case estado is
+      when inicial =>
+        DTR <= '0';
+        saida <= "0000";
+        temDadoRecebido <= '0';
+      when recepcao =>
+        DTR <= '0';
+        saida <= "0001";
+        temDadoRecebido <= '1';
+      when final =>
+        DTR <= '0';
+        saida <= "0010";
+        temDadoRecebido <= '0';
+      when desabilitado =>
+        DTR <= '1';
+        saida <= "1111";
+        temDadoRecebido <= '0';
+    end case;
+   end process;
+end unidade_controle;

--- a/interface_modem/unidade_controle_modem_transmissao.vhd
+++ b/interface_modem/unidade_controle_modem_transmissao.vhd
@@ -1,0 +1,92 @@
+-- VHDL da Unidade de Controle da transmissão
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity unidade_controle_modem_transmissao is
+   port(clock      : in   std_logic;
+        reset      : in   std_logic;
+        liga       : in   std_logic;
+        enviar     : in   std_logic;
+        CTS        : in   std_logic;
+        DTR        : out  std_logic;
+        RTS        : out  std_logic;
+        envioOk    : out  std_logic;
+        saida      : out  std_logic_vector(3 downto 0));  -- controle de estados
+end unidade_controle_modem_transmissao;
+
+architecture unidade_controle of unidade_controle_modem_transmissao is
+type tipo_estado is (inicial, preparacao, transmissao, desabilitado, final);
+signal estado   : tipo_estado;
+
+begin
+  process (clock, estado, reset)
+  begin
+
+    if liga = '0' then
+      estado <= desabilitado;
+    elsif reset = '1' then
+      estado <= inicial;
+
+    elsif (clock'event and clock = '1') then
+      case estado is
+      when inicial =>      -- Aguarda sinal de inicio
+        if enviar = '1' then
+          estado <= preparacao;
+        end if;
+
+      when preparacao =>    -- Espera sinal de controle CTS do modem
+        if CTS = '0' then   -- Ativo em baixo
+          estado <= transmissao;
+        end if;
+
+      when transmissao =>    -- Envia o que estiver na entrada de dados
+        if enviar = '0' then
+          estado <= final;
+        end if;
+
+      when final =>         -- Fim da transmissao serial
+        if CTS = '1' then
+          estado <= inicial;
+        end if;
+
+      when desabilitado =>         -- Circuito desabilitado
+        if liga = '1' then
+          estado <= inicial;
+        end if;
+
+      end case;
+    end if;
+  end process;
+
+  process (estado)
+  begin
+    case estado is
+      when inicial =>
+        saida <= "0000";
+        envioOk <= '0';
+        DTR <= '0';
+        RTS <= '1';
+      when preparacao =>
+        saida <= "0001";
+        envioOk <= '0';
+        DTR <= '0';
+        RTS <= '0';
+      when transmissao =>
+        saida <= "0010";
+        envioOk <= '1';
+        DTR <= '0';
+        RTS <= '0';
+      when final =>
+        saida <= "0011";
+        envioOk <= '0';
+        DTR <= '0';
+        RTS <= '1';
+      when desabilitado =>
+        saida <= "1111";
+        envioOk <= '0';
+        DTR <= '1';
+        RTS <= '1';
+    end case;
+   end process;
+end unidade_controle;

--- a/jogo_velha.vhd
+++ b/jogo_velha.vhd
@@ -9,6 +9,13 @@ entity jogo_velha is
     reset                 : in std_logic;
     start                 : in std_logic;
     entrada_serial        : in std_logic;
+    jogador               : in std_logic;
+    CTS                   : in std_logic;
+    CD                    : in std_logic;
+    RD                    : in std_logic;
+    DTR                   : out std_logic;
+    RTS                   : out std_logic;
+    TD                    : out std_logic;
     saida_serial          : out std_logic;
     jogo_acabado          : out std_logic
   );
@@ -21,10 +28,18 @@ architecture estrutural of jogo_velha is
       clock                 : in std_logic;
       reset                 : in std_logic;
       start                 : in std_logic;
+      jogador               : in std_logic;
       fim_recepcao          : in std_logic;
       recebe_dado           : in std_logic;
       guarda_dado           : in std_logic;
       entrada_serial        : in std_logic;
+      fim_jogo              : in std_logic;
+      CTS                   : in std_logic;
+      CD                    : in std_logic;
+      RD                    : in std_logic;
+      DTR                   : out std_logic;
+      RTS                   : out std_logic;
+      TD                    : out std_logic;
       jogador_atual         : out std_logic;
       saida_serial          : out std_logic;
       habilita_logica       : out std_logic;
@@ -54,10 +69,13 @@ architecture estrutural of jogo_velha is
   signal s_habilita_logica, s_habilita_verificacao: std_logic;
   signal s_jogador_atual: std_logic;
   signal s_dado_paralelo: std_logic_vector(6 downto 0);
+  signal s_jogo_acabado: std_logic;
 
 begin
 
-    interface : interface_jogo port map (clock, reset, start, s_fim_recepcao, s_recebe_dado, s_guarda_dado, entrada_serial, s_jogador_atual, saida_serial, s_habilita_logica, s_habilita_verificacao, s_dado_paralelo, open);
-    logica: logica_jogo port map(clock, reset, s_habilita_logica, s_habilita_verificacao, s_jogador_atual, s_dado_paralelo, s_recebe_dado, s_guarda_dado, jogo_acabado, s_fim_recepcao, open);
+    interface : interface_jogo port map (clock, reset, start, jogador, s_fim_recepcao, s_recebe_dado, s_guarda_dado, entrada_serial, s_jogo_acabado, CTS, CD, RD, DTR, RTS, TD, s_jogador_atual, saida_serial, s_habilita_logica, s_habilita_verificacao, s_dado_paralelo, open);
+    logica: logica_jogo port map(clock, reset, s_habilita_logica, s_habilita_verificacao, s_jogador_atual, s_dado_paralelo, s_recebe_dado, s_guarda_dado, s_jogo_acabado, s_fim_recepcao, open);
+
+    jogo_acabado <= s_jogo_acabado;
 
 end estrutural;


### PR DESCRIPTION
## Issue
#13 #16 

## Descrição
Permite que o jogo da velha seja jogado por duas bancadas

## Objetivo
Adicionar estados para o segundo jogador e a interface com o modem

## Decisões
*  Adicionei uma nova uart para o segundo jogador
*  Adicionei o componente da interface de modem da ex4
*  Criei um estado para o envio e outro para a recepção do dado da outra bancada
